### PR TITLE
Add Dockerfile for backend and docker-compose to spin up DBs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+# Build
+FROM node:alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY . .
+RUN npm run build
+
+#Run
+FROM node:alpine as server
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY --from=builder ./app/prod ./prod
+
+CMD [ "npm", "run", "start" ]

--- a/backend/controllers/mediaController.ts
+++ b/backend/controllers/mediaController.ts
@@ -203,15 +203,15 @@ export const SearchAnimeSentences = async (
       },
       media_info: {
         path_image: `${BASE_URL_MEDIA}/${
-          result.episode.season.media.english_name
+          escape(result.episode.season.media.english_name)
         }/S${String("0" + result.episode.season.number).slice(-2)}/${String(
           "0" + result.episode.number
-        ).slice(-2)}/${result.path_image}`,
+        ).slice(-2)}/${escape(result.path_image)}`,
         path_audio: `${BASE_URL_MEDIA}/${
-          result.episode.season.media.english_name
+          escape(result.episode.season.media.english_name)
         }/S${String("0" + result.episode.season.number).slice(-2)}/${String(
           "0" + result.episode.number
-        ).slice(-2)}/${result.path_audio}`,
+        ).slice(-2)}/${escape(result.path_audio)}`,
       },
     }));
 

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: "3"
+services:
+  pgroonga:
+    image: groonga/pgroonga:latest
+    environment:
+      POSTGRES_DB: ${PG_DATABASE}
+      POSTGRES_USER: ${PG_USER}
+      POSTGRES_PASSWORD: ${PG_PASSWORD}
+    volumes:
+      - local_pgdata:/var/lib/postgresql/data
+    ports:
+      - ${PG_PORT}:5432
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@pgadmin.com
+      PGADMIN_DEFAULT_PASSWORD: password
+      PGADMIN_LISTEN_PORT: 80
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    ports:
+      - 15400:80
+    depends_on:
+      - pgroonga
+
+volumes:
+  local_pgdata:
+  pgadmin-data:
+

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -102,7 +102,7 @@ app.listen(process.env.PORT || 5000, async () => {
         console.error("Unable to connect to the database: ", error);
       });
 
-    //await reSyncDatabase();
+    await reSyncDatabase();
 
     console.log(`Database available. You can freely use this application`);
   } catch (error) {

--- a/backend/sql/pgroonga_setup.sql
+++ b/backend/sql/pgroonga_setup.sql
@@ -1,0 +1,61 @@
+CREATE EXTENSION IF NOT EXISTS pgroonga;
+------------------------------------------
+CREATE OR REPLACE FUNCTION ja_reading (TEXT) RETURNS TEXT AS
+$func$
+DECLARE
+  js      JSON;
+  total   TEXT[] := '{}';
+  reading TEXT;
+BEGIN
+  FOREACH js IN ARRAY pgroonga_tokenize($1,
+    'tokenizer', 'TokenMecab("include_reading", true)')
+  LOOP
+    reading = (js -> 'metadata' ->> 'reading');
+
+    IF reading IS NULL THEN
+      total = total || (js ->> 'value');
+    ELSE
+      total = total || reading;
+    END IF;
+  END LOOP;
+
+  RETURN array_to_string(total, '');
+END;
+$func$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION ja_expand (TEXT) RETURNS TEXT AS
+$func$
+BEGIN
+  IF $1 ~ '[\u4e00-\u9fa5]' THEN
+    RETURN  $1||' OR '||ja_reading($1);
+  END IF;
+
+  RETURN $1;
+END;
+$func$ LANGUAGE plpgsql IMMUTABLE;
+------------------------------------------
+CREATE INDEX pgroonga_tag_index
+    ON nadedb.public."Segment"
+    USING pgroonga (content)
+    WITH (tokenizer='TokenMecab("use_base_form", true, "include_form", true, "include_reading", true)',
+    normalizers='
+        NormalizerNFKC100("unify_kana", true),
+         NormalizerNFKC100("unify_kana_case", true)
+    ');
+
+
+CREATE INDEX idx_tatoeba_jpn_base_form ON nadedb.public."Segment"
+  USING pgroonga ((content || ''))
+  WITH (
+    tokenizer='TokenMecab("use_base_form", true)',
+    normalizer='NormalizerNFKC100("unify_kana", true),
+                NormalizerNFKC100("unify_kana_case", true)'
+  );
+
+CREATE INDEX idx_tatoeba_jpn_reading ON nadedb.public."Segment"
+  USING pgroonga ((content || '' || ''))
+  WITH (
+    tokenizer='TokenMecab("use_reading", true)',
+    normalizer='NormalizerNFKC100("unify_kana", true),
+                NormalizerNFKC100("unify_kana_case", true)    '
+  );

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- pgroonga.yaml
+namespace: nadedb
+images:
+- name: nadedb-backend
+  newName: ghcr.io/brigadasos/nadedb-backend
+  newTag: v0.1.9

--- a/kustomize/base/pgroonga.yaml
+++ b/kustomize/base/pgroonga.yaml
@@ -1,0 +1,78 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: pgroonga-pvolume
+  namespace: nadedb
+  labels:
+    type: local
+    app: pgroonga
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/mnt/data"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pgroonga-pvolume-claim
+  namespace: nadedb
+  labels:
+    app: pgroonga
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgroonga
+  namespace: nadedb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pgroonga
+  template:
+    metadata:
+      labels:
+        app: pgroonga
+    spec:
+      containers:
+        - name: pgroonga
+          image: groonga/pgroonga:latest
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: pgroonga-config
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: pgroongadb
+      volumes:
+        - name: pgroongadb
+          persistentVolumeClaim:
+            claimName: pgroonga-pvolume-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgroonga-service
+  namespace: nadedb
+  labels:
+    app: pgroonga
+spec:
+  type: NodePort
+  ports:
+   - port: 5432
+  selector:
+   app: pgroonga
+


### PR DESCRIPTION
* Run `docker-compose up` to get Postgre (with Pgroonga) and pgAdmin running
* The `.env` file is required to get database credentials
* Add `Dockerfile` to run backend inside a container.
* Add `kustomization.yaml` file to indicate how to deploy the database to the server.
* Add Pgroonga configuration as reference.
* Fix url not working when anime or segment name has spaces.