### PR TITLE
Add missing MediaInfo schema

### DIFF
--- a/frontend_v2/public/nadeshikoapi.yaml
+++ b/frontend_v2/public/nadeshikoapi.yaml
@@ -465,3 +465,13 @@ components:
           type: boolean
         content_es:
           type: string
+
+    MediaInfo:
+      type: object
+      properties:
+        path_image:
+          type: string
+        path_audio:
+          type: string
+        path_video:
+          type: string


### PR DESCRIPTION
## Description


The MediaInfo schema was missing from the OpenAPI spec, preventing API client generation.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Changes Made

- Add missing schema for MediaInfo

## Testing

- [x] I have tested these changes locally using https://github.com/OpenAPITools/openapi-generator and https://github.com/openapi-generators/openapi-python-client

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have checked for any breaking changes

## Additional Notes

Thank you for Nadeshiko! It's a great tool.