### PR TITLE
Add in-memory LRU cache for Elasticsearch statistics queries

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@elastic/elasticsearch": "^8.15.1",
+        "@types/object-hash": "^3.0.6",
         "archiver": "^7.0.1",
         "axios": "^1.7.7",
         "backend": "file:",
@@ -28,8 +29,10 @@
         "helmet": "^8.0.0",
         "http-status-codes": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
+        "lru-cache": "^11.2.4",
         "multer": "^1.4.5-lts.1",
         "nodemailer": "^7.0.12",
+        "object-hash": "^3.0.0",
         "pg": "^8.13.1",
         "pino": "^10.1.1",
         "pino-http": "^11.0.0",
@@ -1101,6 +1104,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/object-hash": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.6.tgz",
+      "integrity": "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==",
+      "license": "MIT"
     },
     "node_modules/@types/pino": {
       "version": "7.0.4",
@@ -4668,10 +4677,13 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -5115,6 +5127,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -5305,6 +5326,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "^8.15.1",
+    "@types/object-hash": "^3.0.6",
     "archiver": "^7.0.1",
     "axios": "^1.7.7",
     "backend": "file:",
@@ -54,8 +55,10 @@
     "helmet": "^8.0.0",
     "http-status-codes": "^2.3.0",
     "jsonwebtoken": "^9.0.2",
+    "lru-cache": "^11.2.4",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^7.0.12",
+    "object-hash": "^3.0.0",
     "pg": "^8.13.1",
     "pino": "^10.1.1",
     "pino-http": "^11.0.0",


### PR DESCRIPTION
This commit implements caching for expensive Elasticsearch statistics
aggregations to significantly improve performance for repeated queries.

Problem:
- Statistics queries (sidebar + category tabs) aggregate all matching documents
- These expensive queries run on every search request
- Statistics only depend on query text + filters, NOT on media/season/episode
- Same statistics returned when user selects different media/episodes

Solution:
- Implemented LRU cache with 15-minute TTL and 1000-entry capacity
- Separate caches for sidebar statistics and category statistics
- Cache keys based on relevant query parameters only:
  * Sidebar: query + category + status + length + excluded_anime_ids
  * Category: query + media + status + length + excluded_anime_ids
- Proper cache hit/miss logging for monitoring

Benefits:
- Dramatically reduces Elasticsearch load for repeated searches
- Near-instant response for cached statistics
- Pagination requests with same query reuse cached statistics
- LRU eviction prevents unbounded memory growth
- Automatic TTL expiration ensures fresh data

Cache management:
- Exported statisticsCache.getStats() for monitoring
- Exported statisticsCache.clear() for manual invalidation