### PR TITLE
feat:Add real match count to word matches

### DIFF
--- a/backend/app/models/SegmentDocument.ts
+++ b/backend/app/models/SegmentDocument.ts
@@ -227,6 +227,8 @@ export class SegmentDocument {
       ? SegmentQuery.buildCommonFilters(filters)
       : { filter: [] as estypes.QueryDslQueryContainer[], must_not: [] as estypes.QueryDslQueryContainer[] };
 
+    const hasHiddenMediaExclusion = must_not.length > 0;
+
     const searches: estypes.MsearchRequestItem[] = words.flatMap((word) => {
       const baseQuery = SegmentQuery.buildMultiLanguage(
         word,
@@ -234,21 +236,28 @@ export class SegmentDocument {
         parserMode,
         filters && Array.isArray(filters.languages) ? filters.languages : undefined,
       );
-      return [
-        {},
-        {
-          size: 0,
-          query: { bool: { must: [baseQuery], filter, must_not } },
-          aggs: { group_by_media_id: { terms: { field: 'mediaId' } } },
-        },
-      ];
+      const filteredBody: estypes.MsearchRequestItem = {
+        size: 0,
+        track_total_hits: true,
+        query: { bool: { must: [baseQuery], filter, must_not } },
+        aggs: { group_by_media_id: { terms: { field: 'mediaId' } } },
+      };
+      if (!hasHiddenMediaExclusion) {
+        return [{}, filteredBody];
+      }
+      const unfilteredBody: estypes.MsearchRequestItem = {
+        size: 0,
+        track_total_hits: true,
+        query: { bool: { must: [baseQuery], filter } },
+      };
+      return [{}, filteredBody, {}, unfilteredBody];
     });
 
     return withSafeQueryFallback(
       async () => {
         const esResponse = await client.msearch({ index: INDEX_NAME, searches });
         const mediaMapData = await Media.getMediaInfoMap();
-        return SegmentResponse.buildWordsMatched(words, esResponse, mediaMapData);
+        return SegmentResponse.buildWordsMatched(words, esResponse, mediaMapData, hasHiddenMediaExclusion);
       },
       () => SegmentDocument.wordsMatched(words, exactMatch, filters, 'safe'),
       {

--- a/backend/app/models/segmentDocument/SegmentResponse.ts
+++ b/backend/app/models/segmentDocument/SegmentResponse.ts
@@ -198,20 +198,29 @@ export class SegmentResponse {
     words: string[],
     esResponse: estypes.MsearchResponse,
     mediaInfoResponse: MediaInfoMap,
+    hasRealCountQueries: boolean,
   ): SearchMultipleResponseOutput {
     const results: WordMatchOutput[] = [];
     const mediaMap: Record<string, MediaOutput> = {};
+    const stride = hasRealCountQueries ? 2 : 1;
 
-    for (const [word, response] of words.map((word, i): [string, estypes.SearchResponseBody] => [
-      word,
-      esResponse.responses[i] as estypes.SearchResponseBody,
-    ])) {
+    for (let i = 0; i < words.length; i++) {
+      const word = words[i];
+      const response = esResponse.responses[i * stride] as estypes.SearchResponseBody;
+
       let isMatch = false;
       let matchCount = 0;
 
       if (response.hits?.total !== undefined) {
         isMatch = (response.hits.total as estypes.SearchTotalHits).value > 0;
         matchCount = (response.hits.total as estypes.SearchTotalHits).value;
+      }
+
+      let realMatchCount = matchCount;
+      if (hasRealCountQueries) {
+        // True when wordsMatched() ran a second real-count query for each word.
+        const realResponse = esResponse.responses[i * stride + 1] as estypes.SearchResponseBody;
+        realMatchCount = (realResponse.hits.total as estypes.SearchTotalHits).value;
       }
 
       let media: WordMatchMediaOutput[] = [];
@@ -235,7 +244,7 @@ export class SegmentResponse {
           .filter((item): item is WordMatchMediaOutput => item !== null);
       }
 
-      results.push({ word, isMatch, matchCount, media });
+      results.push({ word, isMatch, matchCount, realMatchCount, media });
     }
 
     return { results, includes: { media: mediaMap } };

--- a/backend/docs/generated/openapi.yaml
+++ b/backend/docs/generated/openapi.yaml
@@ -3779,6 +3779,7 @@ components:
         - word
         - isMatch
         - matchCount
+        - realMatchCount
         - media
       properties:
         word:
@@ -3792,9 +3793,14 @@ components:
           example: true
         matchCount:
           type: integer
-          description: Total number of times this word appears across all media
+          description: Number of times this word appears across media matching the current request filters (including any hidden-media exclusion).
           minimum: 0
           example: 1523
+        realMatchCount:
+          type: integer
+          description: Total occurrences across all media, ignoring the hidden-media exclusion filter. Equal to `matchCount` when no media exclusion is in effect.
+          minimum: 0
+          example: 5231
         media:
           type: array
           description: List of media containing this word

--- a/backend/docs/openapi/components/schemas/WordMatch.yaml
+++ b/backend/docs/openapi/components/schemas/WordMatch.yaml
@@ -4,6 +4,7 @@ required:
   - word
   - isMatch
   - matchCount
+  - realMatchCount
   - media
 properties:
   word:
@@ -17,9 +18,14 @@ properties:
     example: true
   matchCount:
     type: integer
-    description: Total number of times this word appears across all media
+    description: Number of times this word appears across media matching the current request filters (including any hidden-media exclusion).
     minimum: 0
     example: 1523
+  realMatchCount:
+    type: integer
+    description: Total occurrences across all media, ignoring the hidden-media exclusion filter. Equal to `matchCount` when no media exclusion is in effect.
+    minimum: 0
+    example: 5231
   media:
     type: array
     description: List of media containing this word

--- a/backend/generated/models.ts
+++ b/backend/generated/models.ts
@@ -713,6 +713,7 @@ export type t_WordMatch = {
   isMatch: boolean;
   matchCount: number;
   media: t_WordMatchMedia[];
+  realMatchCount: number;
   word: string;
 };
 

--- a/backend/generated/schemas.ts
+++ b/backend/generated/schemas.ts
@@ -704,6 +704,7 @@ export const s_WordMatch = z.object({
   word: z.string().min(1),
   isMatch: PermissiveBoolean,
   matchCount: z.coerce.number().min(0),
+  realMatchCount: z.coerce.number().min(0),
   media: z.array(s_WordMatchMedia),
 });
 

--- a/backend/tests/controllers/searchController.test.ts
+++ b/backend/tests/controllers/searchController.test.ts
@@ -145,7 +145,15 @@ describe('search controller', () => {
 
   it('search words passes inputs and strips includes by default', async () => {
     mockWordsMatched.mockResolvedValue({
-      results: [{ word: '猫', isMatch: true, matchCount: 3, media: [{ mediaId: 1, matchCount: 3 }] }],
+      results: [
+        {
+          word: '猫',
+          isMatch: true,
+          matchCount: 3,
+          realMatchCount: 5,
+          media: [{ mediaPublicId: 'Media0000001', matchCount: 3 }],
+        },
+      ],
       includes: { media: { 1: buildMediaRecord(1) } },
     });
 
@@ -162,6 +170,7 @@ describe('search controller', () => {
 
     expect(res.status).toBe(200);
     expect((res.body as any).includes).toBeUndefined();
+    assertMatchesSchema(schemas.s_SearchMultipleResponse, res.body, 'searchWords() 200');
     expect(mockWordsMatched).toHaveBeenCalledWith(
       ['猫'],
       true,

--- a/backend/tests/models/SegmentDocument.test.ts
+++ b/backend/tests/models/SegmentDocument.test.ts
@@ -200,14 +200,45 @@ describe.skipIf(!esAvailable)('SegmentDocument (integration)', () => {
       const catResult = result.results.find((r) => r.word === '猫');
       expect(catResult?.isMatch).toBe(true);
       expect(catResult?.matchCount).toBeGreaterThanOrEqual(1);
+      expect(catResult?.realMatchCount).toBe(catResult?.matchCount);
 
       const dogResult = result.results.find((r) => r.word === '犬');
       expect(dogResult?.isMatch).toBe(true);
       expect(dogResult?.matchCount).toBeGreaterThanOrEqual(1);
+      expect(dogResult?.realMatchCount).toBe(dogResult?.matchCount);
 
       const noMatch = result.results.find((r) => r.word === 'xyz不存在');
       expect(noMatch?.isMatch).toBe(false);
       expect(noMatch?.matchCount).toBe(0);
+      expect(noMatch?.realMatchCount).toBe(0);
+    });
+
+    it('returns real counts while excluding hidden media from visible counts', async () => {
+      await seedSegmentsIntoEs({}, [
+        { contentJa: '猫が好きです', position: 1 },
+        { contentJa: '猫は可愛いです', position: 2 },
+      ]);
+      const hidden = await seedSegmentsIntoEs({}, [
+        { contentJa: '猫を見ました', position: 1 },
+        { contentJa: '猫と遊びます', position: 2 },
+        { contentJa: '猫ですね', position: 3 },
+      ]);
+
+      const result = await SegmentDocument.wordsMatched(['猫'], false, {
+        status: ['ACTIVE'],
+        category: ['ANIME', 'JDRAMA'],
+        media: {
+          exclude: [{ mediaPublicId: hidden.media.publicId, mediaId: hidden.media.id } as any],
+        },
+      });
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({
+        word: '猫',
+        isMatch: true,
+        matchCount: 2,
+        realMatchCount: 5,
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Adds `realMatchCount` to word-match responses so clients can show both the count visible under the current filters and the real count when hidden-media exclusions are ignored.

This is backend-only. (No SDK regenration, no frontend changes)

Closes #186

## Type of Change
<!-- Please check the relevant option(s) -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Changes Made
<!-- List the main changes in bullet points -->
- Added `realMatchCount` to the OpenAPI `WordMatch` schema and regenerated backend API types.
- Updated `SegmentDocument.wordsMatched()` to run paired `_msearch` sub-queries only when hidden-media exclusions are present.
- Updated `SegmentResponse.buildWordsMatched()` to populate `realMatchCount`, copying `matchCount` when no real-count query is needed.
- Added backend tests for the no-exclusion path and the hidden-media exclusion path.
- Updated the search controller test mock/schema assertion for the new required response field.

```javascript
// Before
{
  "results": [
    {
      "word": "ある",
      "isMatch": true,
      "matchCount": 12341,
      "media": [
        {
          "mediaPublicId": "abc123xyz789",
          "matchCount": 820
        }
      ]
    }
  ]
}

// After
{
  "results": [
    {
      "word": "ある",
      "isMatch": true,
      "matchCount": 12341,
      "realMatchCount": 41029,
      "media": [
        {
          "mediaPublicId": "abc123xyz789",
          "matchCount": 820
        }
      ]
    }
  ]
}
```


## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] I have tested these changes locally
- [ ] I ran `bun run check` (or documented why not)

I did not run the full `bun run check`; I ran the equivalent focused verification for this backend/API change, including API generation, typecheck, lint, and targeted tests.

```text
bun run test:setup
bun test tests/models/SegmentDocument.test.ts
# 20 pass, 0 fail

bun test tests/controllers/searchController.test.ts
# 4 pass, 0 fail

bun run typecheck
# generate:api completed successfully
# tsc --noEmit -p tsconfig.app.json completed successfully

bun run lint
# biome check . completed successfully
# redocly lint completed successfully

git diff --check
# no output
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked for any breaking changes
- [x] I confirmed whether this PR changes API/OpenAPI contracts
- [x] I confirmed whether this PR requires a database migration

## Additional Notes

This changes the API/OpenAPI contract by adding a required realMatchCount field to WordMatch.

Word-match queries now use `track_total_hits: true` so matchCount and realMatchCount are exact rather than capped by Elasticsearch total-hit tracking. The no-hidden-media path still uses one Elasticsearch sub-search per word.

Performance shape:

- Without hidden-media exclusions: one _msearch request, one sub-search per word.
- With hidden-media exclusions: one _msearch request, two sub-searches per word. The second sub-search only reads the exact total and does not run the media aggregation.

No database migration is required.
