### PR TITLE
fix(frontend): expand context text invisible, boundary detection, aud…

### DIFF
--- a/frontend/app/composables/useSegmentConcatenation.ts
+++ b/frontend/app/composables/useSegmentConcatenation.ts
@@ -12,7 +12,7 @@ interface IConcatenation {
   originalContent: IOriginalContent | null;
 }
 
-type TextFieldBase = { content: string; highlight?: string };
+type TextFieldBase = { content: string; highlight?: string; tokens?: unknown };
 
 /**
  * Concatenate a single text field (content or highlight) between current and adjacent segments.
@@ -68,6 +68,7 @@ function concatLangField<T extends TextFieldBase>(
       ...currentField,
       content: concatTextField(curContent, adjContent, 'both', befContent),
       highlight: concatTextField(curHighlight, adjHighlight, 'both', befHighlight),
+      tokens: null,
     } as T;
   }
 
@@ -75,6 +76,7 @@ function concatLangField<T extends TextFieldBase>(
     ...currentField,
     content: concatTextField(curContent, adjContent, direction),
     highlight: concatTextField(curHighlight, adjHighlight, direction),
+    tokens: null,
   } as T;
 }
 
@@ -134,8 +136,10 @@ export function useSegmentConcatenation() {
       const response = raw ? resolveContextResponse(raw) : null;
 
       if (response && response.segments.length > 0) {
-        const previousSegment = response.segments[0];
-        const nextSegment = response.segments[2];
+        const currentIdx = response.segments.findIndex((s) => s.segment.publicId === result.segment.publicId);
+        if (currentIdx === -1) return;
+        const previousSegment = response.segments[currentIdx - 1];
+        const nextSegment = response.segments[currentIdx + 1];
 
         activeConcatenation = {
           result,
@@ -146,12 +150,8 @@ export function useSegmentConcatenation() {
           },
         };
 
-        let concatenatedAudio: Awaited<ReturnType<typeof concatenateAudios>> | null = null;
-
         if (direction === 'forward') {
           if (!nextSegment) return;
-          audioUrls.push(nextSegment.segment.urls.audioUrl);
-          concatenatedAudio = await concatenateAudios(audioUrls);
 
           result.segment = {
             ...result.segment,
@@ -159,10 +159,17 @@ export function useSegmentConcatenation() {
             textEn: concatLangField(result.segment.textEn, nextSegment.segment.textEn, 'forward'),
             textEs: concatLangField(result.segment.textEs, nextSegment.segment.textEs, 'forward'),
           };
+
+          audioUrls.push(nextSegment.segment.urls.audioUrl);
+          try {
+            const concatenatedAudio = await concatenateAudios(audioUrls);
+            result.blobAudioUrl = concatenatedAudio.blob_url;
+            result.blobAudio = concatenatedAudio.blob;
+          } catch (audioErr) {
+            console.error('Audio concatenation failed:', audioErr);
+          }
         } else if (direction === 'backward') {
           if (!previousSegment) return;
-          audioUrls.unshift(previousSegment.segment.urls.audioUrl);
-          concatenatedAudio = await concatenateAudios(audioUrls);
 
           result.segment = {
             ...result.segment,
@@ -170,11 +177,17 @@ export function useSegmentConcatenation() {
             textEn: concatLangField(result.segment.textEn, previousSegment.segment.textEn, 'backward'),
             textEs: concatLangField(result.segment.textEs, previousSegment.segment.textEs, 'backward'),
           };
+
+          audioUrls.unshift(previousSegment.segment.urls.audioUrl);
+          try {
+            const concatenatedAudio = await concatenateAudios(audioUrls);
+            result.blobAudioUrl = concatenatedAudio.blob_url;
+            result.blobAudio = concatenatedAudio.blob;
+          } catch (audioErr) {
+            console.error('Audio concatenation failed:', audioErr);
+          }
         } else if (direction === 'both') {
           if (!previousSegment || !nextSegment) return;
-          audioUrls.unshift(previousSegment.segment.urls.audioUrl);
-          audioUrls.push(nextSegment.segment.urls.audioUrl);
-          concatenatedAudio = await concatenateAudios(audioUrls);
 
           result.segment = {
             ...result.segment,
@@ -197,14 +210,20 @@ export function useSegmentConcatenation() {
               previousSegment.segment.textEs,
             ),
           };
-        }
 
-        if (concatenatedAudio) {
-          result.blobAudioUrl = concatenatedAudio.blob_url;
-          result.blobAudio = concatenatedAudio.blob;
+          audioUrls.unshift(previousSegment.segment.urls.audioUrl);
+          audioUrls.push(nextSegment.segment.urls.audioUrl);
+          try {
+            const concatenatedAudio = await concatenateAudios(audioUrls);
+            result.blobAudioUrl = concatenatedAudio.blob_url;
+            result.blobAudio = concatenatedAudio.blob;
+          } catch (audioErr) {
+            console.error('Audio concatenation failed:', audioErr);
+          }
         }
       }
-    } catch {
+    } catch (error) {
+      console.error('Segment expansion failed:', error);
       activeConcatenation = { result: null, originalContent: null };
     } finally {
       document.querySelectorAll('#concatenate-button').forEach((e) => {

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/frontend/e2e/specs/search/expand-sentence.spec.ts
+++ b/frontend/e2e/specs/search/expand-sentence.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '../../fixtures';
+import { SearchPage } from '../../pages/SearchPage';
+
+test.describe('Expand sentence', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+    await search.goto('彼女');
+    await search.expectResultsVisible();
+  });
+
+  test('Expand right updates text without crashing', async ({ page }) => {
+    const card = search.segmentCards.first();
+    const jaText = card.getByTestId('segment-japanese-text');
+
+    // Open more dropdown
+    const dropdown = card.getByTestId('more-dropdown');
+    await dropdown.getByTestId('dropdown-toggle').click();
+
+    const menu = dropdown.getByTestId('dropdown-menu');
+    await expect(menu.getByText('Expand (right)')).toBeVisible();
+
+    // Click expand right and wait for context API
+    const responsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('/context') && resp.status() === 200,
+    );
+    await menu.getByText('Expand (right)').click();
+    await responsePromise;
+
+    // Card and Japanese text should remain visible
+    await expect(card).toBeVisible();
+    await expect(jaText).toBeVisible();
+
+    // If a next segment exists, the concatenated text contains a cyan span.
+    // If the segment is at an episode boundary, the text stays the same.
+    // Either outcome is valid as long as nothing crashed.
+    const cyanSpans = jaText.locator('span.text-cyan-200');
+    const count = await cyanSpans.count();
+    expect(count).toBeGreaterThanOrEqual(0);
+  });
+
+  test('Expand left updates text without crashing', async ({ page }) => {
+    const card = search.segmentCards.first();
+    const jaText = card.getByTestId('segment-japanese-text');
+
+    const dropdown = card.getByTestId('more-dropdown');
+    await dropdown.getByTestId('dropdown-toggle').click();
+
+    const menu = dropdown.getByTestId('dropdown-menu');
+    const responsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('/context') && resp.status() === 200,
+    );
+    await menu.getByText('Expand (left)').click();
+    await responsePromise;
+
+    await expect(card).toBeVisible();
+    await expect(jaText).toBeVisible();
+  });
+
+  test('Expand both updates text without crashing', async ({ page }) => {
+    const card = search.segmentCards.first();
+    const jaText = card.getByTestId('segment-japanese-text');
+
+    const dropdown = card.getByTestId('more-dropdown');
+    await dropdown.getByTestId('dropdown-toggle').click();
+
+    const menu = dropdown.getByTestId('dropdown-menu');
+    const responsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('/context') && resp.status() === 200,
+    );
+    await menu.getByText('Expand (both)').click();
+    await responsePromise;
+
+    await expect(card).toBeVisible();
+    await expect(jaText).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

Fixes three bugs in the "Expand context" sentence feature plus intermittent CDN CORS errors silently killing the expansion.

<!-- Link to the issue this PR addresses -->
Closes #194

## Type of Change
<!-- Please check the relevant option(s) -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Changes Made
<!-- List the main changes in bullet points -->
- **Bug 1: Invisible expanded text** — `concatLangField` now sets `tokens: null` after concatenation. Previously, stale tokens caused `SegmentTokenText` to render the original short sentence while the concatenated `content`/`highlight` was ignored. Nullifying tokens forces the `v-if` fallback to `v-html`, which correctly renders the cyan expanded span.
- **Bug 2: Boundary detection at episode edges** — Replaced hardcoded `response.segments[0]` and `[2]` with `findIndex(s => s.segment.publicId === result.segment.publicId)`. At episode boundaries, the backend returns variable-length arrays (1, 2, or 3 segments). Hardcoded indices misidentified neighbors or crashed; the new approach correctly resolves `previousSegment` and `nextSegment` regardless of array length.
- **Bug 3: Audio failure swallowing text update** — Decoupled text mutation from audio concatenation. The expanded sentence text now updates **before** audio fetch begins. Audio concatenation is wrapped in an inner `try/catch`; if the CDN throws (CORS blip, network timeout), `console.error` logs the failure but the text remains expanded instead of silently reverting.
- **E2E coverage** — Added `expand-sentence.spec.ts` with 3 Playwright tests (expand right, left, both) verifying the context API returns 200, the card stays visible, and no crash occurs.

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] I have tested these changes locally

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have checked for any breaking changes
- [x] I confirmed whether this PR changes API/OpenAPI contracts
- [ ] I confirmed whether this PR requires a database migration

