### PR TITLE
fix(discord): rebuild better-sqlite3 against release glibc (2.36)

### DIFF
--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -1,15 +1,22 @@
 FROM oven/bun:1 AS build
 WORKDIR /app
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 make g++ \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 COPY . .
 
 FROM node:24-slim AS release
 WORKDIR /app
+# Rebuild better-sqlite3 native binding against this image's glibc (2.36 on
+# bookworm). The prebuilt .node binary ships from a glibc 2.38 build host and
+# fails to load in the release image with "GLIBC_2.38 not found".
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/node_modules ./node_modules
+RUN npm rebuild better-sqlite3 --build-from-source
 COPY --from=build /app/src ./src
 COPY --from=build /app/package.json ./
 COPY --from=build /app/tsconfig.json ./


### PR DESCRIPTION
The `better-sqlite3@^12.10.0` prebuilt binary was compiled on a glibc 2.38 host (Trixie/Ubuntu 24.04) but the release image is `node:24-slim` on Debian bookworm (glibc 2.36), so the container crashes every ~60s with `GLIBC_2.38 not found`.

This rebuilds the native binding in the release stage against the same glibc the runtime uses.

Triggered by: discord prod container crashloopping every minute since deploy.