### PR TITLE
feat(infra): orphan-chunk-reload worker + tighten HTML max-age to 0

### DIFF
--- a/docs/2026-06-23-orphan-chunk-fix.md
+++ b/docs/2026-06-23-orphan-chunk-fix.md
@@ -1,0 +1,182 @@
+# Orphan Chunk Fix — 2026-06-23 (initial) and 2026-06-24 (recovery Worker + tighter TTL)
+
+## The bug
+
+Users reported: `TypeError: Failed to fetch dynamically imported module: https://nadeshiko.co/_nuxt/bqwT2RnV.js`
+
+After every CLI redeploy, Nuxt produces a new build with new chunk
+hashes. The previous build's chunks age out of CF edge cache within
+~24h, but the previous build's HTML can stay in a user's browser cache
+for the duration of `Cache-Control: max-age=N` on the HTML response.
+
+When that stale HTML runs and tries to dynamic-import an orphan chunk
+URL, the chunk itself may still load from CF edge (it has
+`max-age=31536000, immutable`), but its transitive dynamic-import()
+graph references chunks the new build deleted. The user's browser sees
+the failure and reports the outermost URL in the console, which is
+misleading — that URL loaded fine.
+
+Compounding factor (June 22): the prod frontend was running commit
+`736884465d3a45698fddb8f3a0b187240ab47400` (a CLI-deployed image, not a
+tagged release). Image `last-modified` was 2026-06-22 16:26 UTC, with
+the orphan chunks baked in.
+
+## Round 1 (2026-06-23) — three Cloudflare rules
+
+### 1. `html-no-edge-cache` — Cache Rule
+**Where:** CF dashboard → Caching → Cache Rules
+**Effect:** Cloudflare edge never stores HTML responses for `nadeshiko.co`
+**Why:** Defense in depth — even if a future config change starts emitting edge-cacheable Cache-Control headers, CF won't actually store them.
+**Action parameters:**
+```json
+{"cache": false}
+```
+**Expression:**
+```
+(http.host eq "nadeshiko.co" and not (starts_with(http.request.uri.path, "/_nuxt/") or ends_with(http.request.uri.path, ".css") or ends_with(http.request.uri.path, ".js") or ends_with(http.request.uri.path, ".png") or ends_with(http.request.uri.path, ".svg") or ends_with(http.request.uri.path, ".webp") or ends_with(http.request.uri.path, ".woff") or ends_with(http.request.uri.path, ".woff2") or ends_with(http.request.uri.path, ".ico")))
+```
+**API verification:** `GET /zones/<zone_id>/rulesets/phases/http_request_cache_settings/entrypoint` returns this rule at version 20.
+
+### 2. `v1-api-bypass` — Cache Rule
+**Where:** CF dashboard → Caching → Cache Rules
+**Effect:** Cloudflare edge never stores `/v1/*` responses on `api.nadeshiko.co`
+**Why:** Pre-emptive — once the per-IP rate limiter ships (work in progress as of June 22), CF must NOT cache `/v1/*` responses or the limiter is defeated.
+**Action parameters:**
+```json
+{"cache": false}
+```
+**Expression:**
+```
+(http.host eq "api.nadeshiko.co" and starts_with(http.request.uri.path, "/v1/"))
+```
+
+### 3. `html-cache-control-5s` — Transform Rule (Modify Response Header)
+**Where:** CF dashboard → Rules → Transform Rules → Create rule → Modify Response Header
+**Effect:** Every HTML response for `nadeshiko.co` (excluding static asset paths) gets `Cache-Control: public, max-age=5` injected on the way out to the browser.
+**Why:** Closes the browser-cached-HTML window. Users with stale HTML from yesterday's deploy revalidate within 5 seconds of any interaction, instead of 60 seconds.
+**Header modify:** Set static
+**Header name:** `Cache-Control`
+**Value:** `public, max-age=5`
+**Expression:** (same path-exclusion expression as `html-no-edge-cache`)
+**Verification:** `curl -sSI "https://nadeshiko.co/en?cb=$RANDOM" -A "Mozilla/5.0"` returns `cache-control: public, max-age=5` + `cf-cache-status: DYNAMIC`.
+
+## Round 2 (2026-06-24) — TTL=0 + recovery Worker
+
+The 5s `Cache-Control` value helped but didn't fully recover users whose
+tabs were left open across the deploy window or whose browser held HTML
+through bfcache. Two additions:
+
+### 4. `html-cache-control-0s` — tighter Transform Rule
+**Change:** Update the existing `html-cache-control-5s` Transform Rule's
+value from `public, max-age=5` to `public, max-age=0`. CF revalidation
+becomes mandatory on every navigation; the browser cache window for
+HTML effectively drops to zero. Trade-off: one extra CF revalidation
+per page view (essentially free against the kamal-proxy origin). Worth
+it during the orphan window; can be reverted to `5` once the deploy
+pipeline stops producing orphans.
+
+**How to apply:** CF dashboard → Rules → Transform Rules →
+`html-cache-control-5s` (rename to `html-cache-control-0s` if you want
+to be tidy) → edit → Value field. OR via API: `PUT` the rule with the
+new value. The `Set static` action type means a non-empty value
+overwrites, no need to first clear.
+
+### 5. CF Worker — `nadeshiko-orphan-chunk-reload`
+**Where:** `infra/orphan-chunk-reload-worker/` in this repo.
+**Effect:** Catches the case the Transform Rule can't — users whose
+browser cached HTML *before* the rule took effect, or whose bfcache
+holds stale HTML across deploys. For any `/_nuxt/*.js` request on
+`nadeshiko.co` that returns 404 from origin, the Worker returns a tiny
+ES module that calls `window.location.reload()`. The browser's
+dynamic-import() resolves (no error to the app), the page reloads,
+the user gets fresh HTML pointing at the new build's chunk hashes.
+
+**Deploy:** `cd infra/orphan-chunk-reload-worker && bun install && bun run deploy`.
+The Worker's `wrangler.toml` pins the route `nadeshiko.co/*` so all
+traffic to that host flows through it. Anything outside `/_nuxt/*.js`
+is a literal `return fetch(request)` — no overhead, no behavior change.
+
+**Why a Worker and not a Transform Rule:** Transform Rules can't
+rewrite a 404 into a 200-with-different-body. They modify headers, not
+status codes or bodies. The recovery requires actually replacing the
+chunk's response with the reload-trigger script, which only a Worker
+can do.
+
+## Architectural decision
+
+The team had already decided (per `frontend/nuxt.config.ts` comment at
+line 306-308) that HTML caching decisions live in Cloudflare Cache
+Rules / Transform Rules, NOT in `nuxt.config.ts` `routeRules`. The
+recovery Worker follows the same principle: it's infrastructure, lives
+in `infra/` like the existing seed-worker, deployable independently of
+the app code. Anyone debugging cache behavior in 6 months looks in two
+places (CF dashboard + `infra/orphan-chunk-reload-worker/`), not three
+(CF + nuxt.config.ts + scattered logic).
+
+## What we did NOT change
+
+- `frontend/nuxt.config.ts` — unchanged. The Transform Rule approach
+  respects the existing architecture.
+- `frontend/server/middleware/00-locale-router.ts` — unchanged. Already
+  correctly sets `Cache-Control: private, no-store` for `/` and
+  unprefixed redirects.
+- `_nuxt/*` chunk cache headers — unchanged
+  (`public, max-age=31536000, immutable`). Hash-based filenames never
+  collide, so 1-year browser cache is safe.
+- The orphan chunks themselves — not deleted from CF edge. They age out
+  naturally within their 1-year immutable window. No new HTML
+  references them.
+
+## Verification matrix
+
+After Round 2 is fully deployed:
+
+| URL | Expected `cache-control` | Expected `cf-cache-status` | Expected behavior |
+|---|---|---|---|
+| `https://nadeshiko.co/en` | `public, max-age=0` | `DYNAMIC` | Re-fetches on every nav |
+| `https://nadeshiko.co/_nuxt/<currentHash>.js` | `public, max-age=31536000, immutable` | `HIT` (cached) | Passes through Worker untouched |
+| `https://nadeshiko.co/_nuxt/<orphanHash>.js` (purged from CF edge) | `no-store` | n/a | Worker returns reload-trigger JS, 200 |
+| `https://api.nadeshiko.co/v1/auth/get-session` | `no-store` | `DYNAMIC` | Worker not in route, falls through to origin |
+
+## User-side action (for current affected users)
+
+Users still seeing the orphan chunk error today need to hard-refresh:
+- macOS Chrome/Safari/Firefox: `Cmd + Shift + R`
+- Windows/Linux: `Ctrl + Shift + R` or `Ctrl + F5`
+
+This clears their browser's local HTML cache. Once the Worker is
+deployed + the Transform Rule is at `max-age=0`, affected users will
+self-heal on their next navigation (no hard refresh required).
+
+## Token / secret cleanup
+
+- API token used for rule creation: written to `/tmp/cf_token_dir/cf_token`
+  with `chmod 600`, then `shred -u` and `rmdir`.
+- Pre-existing `/tmp/cf_token` (older `cfut_` token from June 20) also
+  `shred -u`'d.
+- Both tokens should still be **rotated in CF dashboard** as a
+  precaution.
+
+## What I learned (worth remembering)
+
+1. CF Cache Rules and Transform Rules share the same expression parser
+   — same fields, same operators. Neither supports
+   `http.response.content_type` for filtering, even though some docs
+   suggest it does.
+2. CF docs contain a misleading example claiming
+   `http.response.content_type` works in Transform Rules; it does not.
+   Use path-based filtering instead.
+3. The Cache Rule API uses `set_cache_settings` with `cache: false` to
+   bypass cache. The dashboard exposes this as "Bypass cache" but the
+   API doesn't accept the verb `bypass`.
+4. `browser_ttl` in Cache Rules only modifies existing Cache-Control
+   headers from origin — it does NOT inject one if origin doesn't send
+   one. If origin sends no Cache-Control (as Nuxt's `routeRules` does
+   by design in this codebase), `browser_ttl` is a no-op.
+5. Transform Rule modifications to `cache-control` header do NOT affect
+   CF caching behavior — only browser behavior. (CF evaluates caching
+   before applying response header modifications.)
+6. Transform Rules can't change response status codes or bodies. A
+   404→200-with-reload-body recovery requires a CF Worker. Same applies
+   to any "serve this synthetic response when origin returns X" use
+   case.

--- a/infra/orphan-chunk-reload-worker/.gitignore
+++ b/infra/orphan-chunk-reload-worker/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.wrangler/

--- a/infra/orphan-chunk-reload-worker/README.md
+++ b/infra/orphan-chunk-reload-worker/README.md
@@ -1,0 +1,126 @@
+# Orphan Chunk Reload Worker
+
+CF Worker that self-heals users hitting the
+`Failed to fetch dynamically imported module: /_nuxt/<hash>.js` error
+after a Nuxt deploy that changed chunk hashes.
+
+## What it does
+
+When the browser's cached HTML references a chunk the current build no
+longer ships, the chunk request hits this Worker. The Worker asks the
+origin (bypassing CF edge cache), and:
+
+- **If origin returns 404** (chunk is gone): returns a tiny ES module
+  that calls `window.location.reload()`. The browser's dynamic-import
+  resolves cleanly, then the page reloads and the user fetches fresh
+  HTML pointing at the new build's chunk hashes.
+- **If origin returns anything else** (chunk exists, 5xx, etc.):
+  passes the response through unchanged.
+- **If the request URL doesn't match `/_nuxt/*.js` on `nadeshiko.co`**:
+  passes through unchanged. Every other request to the zone is a
+  no-op for this Worker.
+
+## Why it exists
+
+After every CLI redeploy, Nuxt produces a new build with new chunk
+hashes. The previous build's chunks age out of CF edge cache within
+~24h, but the previous build's HTML can stay in a user's browser cache
+for the duration of `Cache-Control: max-age=N` on the HTML response.
+
+When that stale HTML runs and tries to dynamic-import an orphan chunk
+URL, the chunk itself may still load from CF edge (it has
+`max-age=31536000, immutable`), but its transitive dynamic-import()
+graph references chunks the new build deleted. The user's browser sees
+the failure and reports the outermost URL in the console, which is
+misleading — that URL loaded fine.
+
+The Transform Rule `html-cache-control-5s` shrinks the forward window
+to 5s. This Worker covers the backward window: tabs left open across
+the deploy, users on slow `Cache-Control` overrides, etc.
+
+## Scope
+
+- **Hosts**: `nadeshiko.co` only. `api.nadeshiko.co`, `stg.nadeshiko.co`,
+  `api-stg.nadeshiko.co` are NOT routed.
+- **Paths**: only `/_nuxt/*.js`. HTML, API routes, static assets,
+  images, fonts all pass through.
+- **Methods**: any (GET is the realistic case; HEAD, OPTIONS, etc. fall
+  through the gate too).
+- **Caching**: the Worker's own outbound fetch to origin uses
+  `cf: { cacheTtl: 0, cacheEverything: false }` to bypass the CF edge
+  cache for this code path, so we always observe the current state of
+  the chunk. The synthetic reload-trigger response sets
+  `Cache-Control: no-store` so it can't be cached anywhere downstream.
+
+## Deploy
+
+```bash
+cd infra/orphan-chunk-reload-worker
+bun install
+bun run deploy
+```
+
+The `wrangler.toml` pins `account_id = 69706df70c95c734ba43a679b10a5bf9`
+and a `[[routes]]` entry for `nadeshiko.co/*`. The route takes
+precedence over any earlier Worker routes on the zone — make sure no
+other Worker is already covering the same pattern.
+
+## Testing locally
+
+```bash
+bun run dev
+# wrangler will start a local server; test:
+curl -sI http://localhost:8787/_nuxt/nonexistent-test-chunk.js
+# Should return 200 with Content-Type: application/javascript
+```
+
+For an end-to-end test against prod:
+
+1. Open `https://nadeshiko.co/en` in a browser.
+2. Open DevTools → Network → filter by `JS`.
+3. Note a current chunk URL (e.g. `/en/_nuxt/B5PXAU2c.js`-equivalent).
+4. Trigger a synthetic orphan: rename the chunk URL in DevTools'
+   network override, or run
+   `curl -sI "https://nadeshiko.co/_nuxt/nonexistent-deadbeef.js" -A "Mozilla/5.0"`.
+5. Confirm the response is `200 application/javascript` with
+   `Cache-Control: no-store`, body starts with `if (typeof window ...)`.
+
+To test the happy path: any existing `/_nuxt/*.js` chunk should return
+its normal `application/javascript` body with the kamal-proxy cache
+headers, NOT the reload-trigger.
+
+## Rollback
+
+The route is the only thing that wires this Worker into traffic. To
+disable without removing the deployment:
+
+1. CF dashboard → Workers & Pages → `nadeshiko-orphan-chunk-reload` →
+   Settings → Triggers → Routes.
+2. Delete the `nadeshiko.co/*` route entry.
+3. Save.
+
+Subsequent requests will route directly to origin, no Worker
+intervention.
+
+## Limitations / known gaps
+
+- **The reload loses client state.** Forms in flight, partial scrolls,
+  the back-stack entry — all gone. Acceptable because the failure mode
+  is a broken page anyway; better to land on a fresh, working page
+  than to leave the user on a half-broken one.
+- **A 404 in the orphan set is the only signal we trust.** If kamal-proxy
+  or CF returns a 5xx for a chunk that actually exists, we pass the 5xx
+  through. The user sees the same error they'd see without the Worker.
+- **The Worker doesn't fix the root cause.** New CLI redeploys create
+  new orphans; this Worker recovers affected users after the fact. The
+  real fix is to get tagged releases flowing through `release.yml`
+  again (and/or to ship a deploy-day CF purge of
+  `/_nuxt/*` not referenced by the new build). See
+  `docs/2026-06-23-orphan-chunk-fix.md` for context.
+
+## Files
+
+- `src/index.ts` — Worker source.
+- `wrangler.toml` — name, account_id, route binding.
+- `package.json` — wrangler + workers-types devDependencies.
+- `tsconfig.json` — strict TS, workers-types lib only.

--- a/infra/orphan-chunk-reload-worker/package.json
+++ b/infra/orphan-chunk-reload-worker/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nadeshiko-orphan-chunk-reload-worker",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260613.1",
+    "wrangler": "^4.98.0"
+  }
+}

--- a/infra/orphan-chunk-reload-worker/src/index.ts
+++ b/infra/orphan-chunk-reload-worker/src/index.ts
@@ -1,0 +1,85 @@
+// nadeshiko-orphan-chunk-reload
+//
+// Recovery for the "Failed to fetch dynamically imported module: /_nuxt/<hash>.js"
+// error that hits users whose browser holds HTML from a previous Nuxt build.
+//
+// Mechanism: when a browser cached HTML points at a chunk URL that the
+// current build no longer ships, the chunk request hits this Worker, the
+// Worker asks origin, gets a 404, and returns a tiny ES module that calls
+// window.location.reload(). The browser's dynamic-import() resolves cleanly
+// (no error), the reload runs, the user fetches fresh HTML pointing at the
+// new build's chunk hashes. Self-healing.
+//
+// Narrow scope:
+//   - Only matches /_nuxt/*.js paths
+//   - Only matches nadeshiko.co (other hosts pass through untouched)
+//   - Only acts on a 404 from origin; all other statuses pass through
+//   - On Worker/network errors, passes through (no reload-thrash)
+//
+// See infra/orphan-chunk-reload-worker/README.md for the rationale and
+// deploy instructions.
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    // Gate: only act on /_nuxt/*.js paths. Everything else falls through
+    // to origin unchanged. This keeps the Worker from doing anything on
+    // the vast majority of traffic (HTML, API, assets).
+    if (
+      url.hostname !== "nadeshiko.co" ||
+      !url.pathname.startsWith("/_nuxt/") ||
+      !url.pathname.endsWith(".js")
+    ) {
+      return fetch(request);
+    }
+
+    // Ask origin. Don't go through CF cache here — we want to observe the
+    // current state of the chunk on the running container. If the chunk
+    // exists, it loads fast from the kamal-proxy origin anyway.
+    //
+    // The "cf" cache hint on fetch init is a CF extension — workers-types
+    // doesn't surface it on the standard RequestInit, so cast to
+    // RequestInit to satisfy strict TS. wrangler's runtime accepts it.
+    let originResponse: Response;
+    try {
+      const init = { cf: { cacheTtl: 0, cacheEverything: false } } as RequestInit;
+      originResponse = await fetch(request, init);
+    } catch {
+      // Transient network error — pass the original request through so
+      // the browser sees a real network failure rather than a synthetic
+      // 404/reload. This prevents reload-thrash on kamal-proxy blips.
+      return fetch(request);
+    }
+
+    if (originResponse.status !== 404) {
+      // Happy path: chunk exists, return origin's response as-is.
+      return originResponse;
+    }
+
+    // Orphan chunk confirmed. Return a valid ES module that triggers a
+    // page reload. The browser's dynamic-import() resolves (no error
+    // surfaced to the app), then the reload kicks in. Fresh HTML next.
+    //
+    // The script is wrapped in a `try` so a non-browser context (rare
+    // but possible — e.g. fetch() from a test runner) doesn't throw.
+    const reloadScript = `
+if (typeof window !== "undefined" && window.location && typeof window.location.reload === "function") {
+  try { window.location.reload(); } catch (_) {}
+}
+export default {};
+`.trim();
+
+    return new Response(reloadScript, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/javascript; charset=utf-8",
+        // Don't let this synthetic response cache anywhere. If CF caches
+        // it, an unrelated 404 could end up serving the reload-trigger
+        // to a chunk URL that the new build DOES ship but with a slow
+        // cold-cache. Keep the response transient.
+        "Cache-Control": "no-store",
+      },
+    });
+  },
+};

--- a/infra/orphan-chunk-reload-worker/tsconfig.json
+++ b/infra/orphan-chunk-reload-worker/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"]
+}

--- a/infra/orphan-chunk-reload-worker/wrangler.toml
+++ b/infra/orphan-chunk-reload-worker/wrangler.toml
@@ -1,0 +1,13 @@
+name = "nadeshiko-orphan-chunk-reload"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+account_id = "69706df70c95c734ba43a679b10a5bf9"
+
+# Route all nadeshiko.co requests through this Worker. The Worker is a
+# pass-through for everything except /_nuxt/*.js; for those paths it
+# detects an origin 404 and returns a tiny ES module that reloads the
+# page, recovering users whose browser cached stale HTML after a deploy.
+# See README.md for the design rationale and deployment notes.
+[[routes]]
+pattern = "nadeshiko.co/*"
+zone_name = "nadeshiko.co"


### PR DESCRIPTION
## Summary

Two changes that work together to recover users hitting `Failed to fetch dynamically imported module: /_nuxt/<hash>.js` after a deploy:

1. **New CF Worker** (`infra/orphan-chunk-reload-worker/`) — for any `/_nuxt/*.js` request on `nadeshiko.co` that returns 404 from origin, returns a tiny ES module that calls `window.location.reload()`. The browser's dynamic-import() resolves cleanly, the page reloads, fresh HTML points at the new build's chunk hashes.
2. **Doc update** (`docs/2026-06-23-orphan-chunk-fix.md`) — records the companion Transform Rule change: `html-cache-control-5s` → `html-cache-control-0s`, so every HTML navigation triggers a CF revalidation. The Worker covers the backward window (tabs left open across the deploy, bfcache) that the Transform Rule cannot.

## Why both

The 5s `Cache-Control` shipped 2026-06-23 narrowed the *forward* window — new HTML stays in browser cache for 5s instead of the previous default. It does nothing for users who already have stale HTML cached before the rule took effect, or whose bfcache holds HTML across deploys. The Worker catches those: any browser still trying to fetch an orphan chunk gets a graceful reload instead of a broken module error.

## What needs CF-side action

- Deploy the Worker: `cd infra/orphan-chunk-reload-worker && bun install && bun run deploy`
- Update the existing Transform Rule value from `public, max-age=5` to `public, max-age=0` (CF dashboard → Rules → Transform Rules → `html-cache-control-5s`)

Neither change is deployable from this PR alone — both are Cloudflare dashboard operations. The PR contains the code + documentation; the actual CF changes are a follow-up.

## Test plan

After deploy + Transform Rule update:

- [ ] `curl -sSI 'https://nadeshiko.co/en?cb=$RANDOM' -A 'Mozilla/5.0'` → `cache-control: public, max-age=0`
- [ ] `curl -sSI 'https://nadeshiko.co/_nuxt/nonexistent-deadbeef.js' -A 'Mozilla/5.0'` → `200`, `content-type: application/javascript`, body starts with `if (typeof window ...`
- [ ] `curl -sSI 'https://nadeshiko.co/_nuxt/<currentHash>.js' -A 'Mozilla/5.0'` → `200`, normal chunk body, NO reload-trigger
- [ ] Open a real browser, navigate `https://nadeshiko.co/en`, DevTools → Network → JS. Manually replace one chunk URL with `/_nuxt/nonexistent-test.js`. Confirm page reloads instead of showing broken module error.
- [ ] `curl -sSI 'https://api.nadeshiko.co/v1/auth/get-session'` → unchanged (Worker not in route for this host).

## Risk

Low. The Worker is a narrow-scoped pass-through:
- Only `/_nuxt/*.js` paths on `nadeshiko.co` change behavior.
- Everything else (HTML, API, assets) is a literal `return fetch(request)` — zero overhead.
- Network errors fall through to a normal fetch (no reload-thrash on kamal-proxy blips).
- The reload loses client state (scroll, form input). Acceptable because the failure mode is a broken page anyway; better to land on a fresh, working page than leave the user half-broken.

## Rollback

- Worker: CF dashboard → Workers & Pages → `nadeshiko-orphan-chunk-reload` → Settings → Triggers → Routes → delete the `nadeshiko.co/*` route entry. Subsequent requests go directly to origin.
- Transform Rule: revert `html-cache-control-0s` to `public, max-age=5` in CF dashboard. Or disable the rule entirely.

## What we did NOT change

- `frontend/nuxt.config.ts` — unchanged (HTML caching decisions live in CF, per existing architecture).
- `frontend/server/middleware/00-locale-router.ts` — unchanged.
- The orphan chunks themselves — not deleted from CF edge. They age out naturally.

See `docs/2026-06-23-orphan-chunk-fix.md` for the full context, the original three CF rules, and the verification matrix.