### PR TITLE
fix: migrate production Tailscale endpoints

### DIFF
--- a/backend/config/deploy.prod.yml
+++ b/backend/config/deploy.prod.yml
@@ -68,7 +68,7 @@ accessories:
   postgres:
     image: postgres:17
     host: nadeshiko
-    port: "100.114.126.96:5432:5432"
+    port: "100.95.40.11:5432:5432"
     options:
       # Memory limit: 1GB (current ~310MB, 3x headroom)
       # Postgres persists data to disk, safe to OOM-kill and restart
@@ -90,7 +90,7 @@ accessories:
   elasticsearch:
     image: ghcr.io/davafons/nadeshiko-elasticsearch:8.17.10
     host: nadeshiko
-    port: "100.114.126.96:9200:9200"
+    port: "100.95.40.11:9200:9200"
     env:
       secret:
         - ELASTICSEARCH_ADMIN_PASSWORD

--- a/backend/scripts/remote-db.sh
+++ b/backend/scripts/remote-db.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 # Replaces the old toolbox accessory: no admin credentials live on the server,
 # no separate image to build/push, no always-running container.
 
-REMOTE_HOST="100.114.126.96"
+REMOTE_NODE="nadeshiko"
+REMOTE_HOST=""
 PROD_FLAG="--allow-prod"
 
 usage() {
@@ -62,7 +63,7 @@ if [[ ! -f "$SECRETS_FILE" ]]; then
 fi
 
 if ! command -v tailscale >/dev/null 2>&1; then
-  echo "error: tailscale CLI not found - this script needs Tailscale to reach $REMOTE_HOST" >&2
+  echo "error: tailscale CLI not found - this script needs Tailscale to reach $REMOTE_NODE" >&2
   exit 1
 fi
 
@@ -71,8 +72,18 @@ if ! tailscale status >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! ping -c 1 -W 2 "$REMOTE_HOST" >/dev/null 2>&1; then
-  echo "error: cannot reach $REMOTE_HOST over Tailscale" >&2
+# `tailscale ping` resolves peer names even when the operating system is not
+# accepting MagicDNS. Extract the current IPv4 address instead of pinning it.
+PING_OUTPUT="$(tailscale ping --timeout=5s --c=1 "$REMOTE_NODE" 2>&1)" || {
+  echo "error: cannot reach $REMOTE_NODE over Tailscale" >&2
+  echo "$PING_OUTPUT" >&2
+  exit 1
+}
+if [[ "$PING_OUTPUT" =~ \(([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\) ]]; then
+  REMOTE_HOST="${BASH_REMATCH[1]}"
+else
+  echo "error: could not determine $REMOTE_NODE Tailscale IPv4 address" >&2
+  echo "$PING_OUTPUT" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- update production PostgreSQL and Elasticsearch binds to the Nadeshiko node address in the Jonathan tailnet
- make `remote-db.sh` discover the current Nadeshiko IPv4 through `tailscale ping` instead of pinning a node address
- keep remote DB commands working when operating-system MagicDNS integration is disabled

## Validation

- `bash -n backend/scripts/remote-db.sh`
- parsed production/staging/base Kamal YAML successfully
- live discovery returned `100.95.40.11` for `nadeshiko`
- confirmed no `100.114.126.96` references remain in the repository
- production `/up`, `/v1/auth/ok`, `/v1/auth/get-session`, and frontend currently return HTTP 200

## Required out-of-repo migration

Before the next deploy, regenerate the Tailscale OAuth client in the `jonathan.197ariza@gmail.com` tailnet with `tag:ci`, then replace repository secrets `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET`. The existing secrets were last updated in February and belong to the previous tailnet.