### PR TITLE
fix: stop localized Nuxt error redirect loop

### DIFF
--- a/frontend/server/middleware/00-locale-router.ts
+++ b/frontend/server/middleware/00-locale-router.ts
@@ -1,18 +1,5 @@
 import { LOCALE_PREFERENCE_COOKIE_NAME, SUPPORTED_LOCALES, type SupportedLocale } from '~/utils/i18n';
-
-const RESERVED_PREFIXES = [
-  '/_nuxt/',
-  '/_i18n/',
-  '/api/',
-  '/v1/',
-  '/__sitemap__',
-  '/sitemap',
-  '/docs/',
-  '/.well-known/',
-  '/media/',
-];
-
-const RESERVED_EXACT = new Set(['/up', '/robots.txt', '/opensearch.xml', '/favicon.ico']);
+import { isReservedLocalePath } from '../utils/localeRouting';
 
 function isSupportedLocale(value: string | null | undefined): value is SupportedLocale {
   return value !== null && value !== undefined && (SUPPORTED_LOCALES as readonly string[]).includes(value);
@@ -23,14 +10,6 @@ function getLocalePrefix(path: string): SupportedLocale | null {
     if (path === `/${locale}` || path.startsWith(`/${locale}/`)) return locale;
   }
   return null;
-}
-
-function isReservedPath(path: string): boolean {
-  if (RESERVED_EXACT.has(path)) return true;
-  if (RESERVED_PREFIXES.some((p) => path.startsWith(p))) return true;
-  // Files at root: /github-xxx.png, /logo-xxx.webp, /sitemap-en.xml, etc.
-  if (/^\/[^/]+\.[a-zA-Z0-9]+$/.test(path)) return true;
-  return false;
 }
 
 function pickLocaleFromAcceptLanguage(header: string | undefined): SupportedLocale | null {
@@ -54,7 +33,7 @@ export default defineEventHandler((event) => {
   const url = getRequestURL(event);
   const path = url.pathname;
 
-  if (isReservedPath(path)) return;
+  if (isReservedLocalePath(path)) return;
   if (getLocalePrefix(path)) return;
 
   const search = url.search;

--- a/frontend/server/utils/localeRouting.test.ts
+++ b/frontend/server/utils/localeRouting.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { isReservedLocalePath } from './localeRouting';
+
+describe('isReservedLocalePath', () => {
+  it('keeps Nuxt internal error rendering outside locale redirects', () => {
+    expect(isReservedLocalePath('/__nuxt_error')).toBe(true);
+  });
+
+  it('does not reserve user-facing content paths', () => {
+    expect(isReservedLocalePath('/about')).toBe(false);
+    expect(isReservedLocalePath('/blog/example')).toBe(false);
+  });
+});

--- a/frontend/server/utils/localeRouting.ts
+++ b/frontend/server/utils/localeRouting.ts
@@ -1,0 +1,21 @@
+const RESERVED_PREFIXES = [
+  '/_nuxt/',
+  '/_i18n/',
+  '/api/',
+  '/v1/',
+  '/__sitemap__',
+  '/sitemap',
+  '/docs/',
+  '/.well-known/',
+  '/media/',
+];
+
+const RESERVED_EXACT = new Set(['/__nuxt_error', '/up', '/robots.txt', '/opensearch.xml', '/favicon.ico']);
+
+export function isReservedLocalePath(path: string): boolean {
+  if (RESERVED_EXACT.has(path)) return true;
+  if (RESERVED_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;
+  // Files at root: /github-xxx.png, /logo-xxx.webp, /sitemap-en.xml, etc.
+  if (/^\/[^/]+\.[a-zA-Z0-9]+$/.test(path)) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
- reserve Nuxt internal `/__nuxt_error` from locale redirects
- extract reserved locale-path classification into a testable helper
- add regression coverage for internal and user-facing paths

## Root cause
The locale middleware redirected `/__nuxt_error` to `/en/__nuxt_error`. The localized catch-all CMS page then treated `__nuxt_error` as a content slug, raised a second 404, and recursively re-entered Nuxt error handling.

## Validation
- focused regression: 2 passed
- frontend tests: 62 passed
- frontend lint: pass
- frontend typecheck: pass
- git diff --check: pass