### PR TITLE
test: target visible media card elements

### DIFF
--- a/frontend/e2e/pages/MediaPage.ts
+++ b/frontend/e2e/pages/MediaPage.ts
@@ -31,7 +31,7 @@ export class MediaPage {
   }
 
   async expectLoaded() {
-    await expect(this.mediaCards.first()).toBeVisible({ timeout: 15_000 });
+    await expect(this.mediaCardContainers.first()).toBeVisible({ timeout: 15_000 });
   }
 
   async expectListLoaded() {
@@ -39,7 +39,7 @@ export class MediaPage {
   }
 
   async clickFirstMedia() {
-    await this.mediaCards.first().click();
+    await this.mediaCardContainers.first().getByTestId('media-card-title').click();
     await this.page.waitForURL(/\/search\?media=/);
   }
 


### PR DESCRIPTION
## Summary
- wait for the visible media-card container instead of its zero-size anchor wrapper
- click the visible linked title when testing media navigation

## Evidence
The rendered card wrapper is 106×291 px and the title link is 106×40 px. The `data-testid="media-card"` anchor has a 0×0 bounding box because its cover child is absolutely positioned, so Playwright correctly reports that wrapper as hidden even while the card is visible.

## Validation
- browser click on the title navigates to `/en/search?media=...`
- frontend lint: pass
- frontend typecheck: pass
- frontend tests: 62 passed
- Playwright discovery: pass
- git diff --check: pass