### PR TITLE
test: finalize locale-aware E2E assertions

### DIFF
--- a/frontend/e2e/specs/developer-api-keys.spec.ts
+++ b/frontend/e2e/specs/developer-api-keys.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '../auth';
 import { DeveloperPage } from '../pages/DeveloperPage';
 
 test.describe('Developer API Keys', () => {
+  test.describe.configure({ mode: 'serial' });
+
   test('navigates to developer tab', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/user/developer');
     await expect(authenticatedPage).toHaveURL(/\/[a-z]{2}\/user\/developer$/);

--- a/frontend/e2e/specs/header-navigation.spec.ts
+++ b/frontend/e2e/specs/header-navigation.spec.ts
@@ -26,7 +26,7 @@ test.describe('Header Navigation', () => {
     await header.openProfileDropdown();
     await header.settingsLink.click();
 
-    await expect(authenticatedPage).toHaveURL('/user/settings', { timeout: 10_000 });
+    await expect(authenticatedPage).toHaveURL(/\/[a-z]{2}\/user\/settings$/, { timeout: 10_000 });
   });
 
   test('navigates to collections from profile dropdown', async ({ authenticatedPage }) => {
@@ -36,7 +36,7 @@ test.describe('Header Navigation', () => {
     await header.openProfileDropdown();
     await header.collectionsLink.click();
 
-    await expect(authenticatedPage).toHaveURL('/user/collections', { timeout: 10_000 });
+    await expect(authenticatedPage).toHaveURL(/\/[a-z]{2}\/user\/collections$/, { timeout: 10_000 });
   });
 
   test('navigates to activity from profile dropdown', async ({ authenticatedPage }) => {
@@ -46,6 +46,6 @@ test.describe('Header Navigation', () => {
     await header.openProfileDropdown();
     await header.activityLink.click();
 
-    await expect(authenticatedPage).toHaveURL('/user/activity', { timeout: 10_000 });
+    await expect(authenticatedPage).toHaveURL(/\/[a-z]{2}\/user\/activity$/, { timeout: 10_000 });
   });
 });

--- a/frontend/e2e/specs/navbar.spec.ts
+++ b/frontend/e2e/specs/navbar.spec.ts
@@ -29,6 +29,6 @@ test.describe('Navbar links', () => {
   test('logo navigates to homepage', async ({ page }) => {
     await page.goto('/about');
     await page.getByRole('link', { name: 'Nadeshiko' }).first().click();
-    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveURL(/\/[a-z]{2}\/?$/);
   });
 });

--- a/frontend/e2e/specs/search/dropdown-menus.spec.ts
+++ b/frontend/e2e/specs/search/dropdown-menus.spec.ts
@@ -35,7 +35,7 @@ test.describe('Dropdown menus', () => {
     await expect(menu.getByText('Image + Audio')).toBeVisible();
     await expect(menu.getByText('Image', { exact: true })).toBeVisible();
     await expect(menu.getByText('Audio', { exact: true })).toBeVisible();
-    await expect(menu.getByText('Japanese sentence')).toBeVisible();
+    await expect(menu.getByText('Japanese sentence', { exact: true })).toBeVisible();
     await expect(menu.getByText('English sentence')).toBeVisible();
     await expect(menu.getByText('Spanish sentence')).toBeVisible();
   });
@@ -76,7 +76,7 @@ test.describe('Dropdown menus', () => {
     await expect(dropdown).toHaveClass(/nd-dropdown-open/);
 
     const menu = dropdown.getByTestId('dropdown-menu');
-    await menu.getByText('Japanese sentence').click();
+    await menu.getByText('Japanese sentence', { exact: true }).click();
 
     await expect(dropdown).not.toHaveClass(/nd-dropdown-open/);
   });


### PR DESCRIPTION
## Summary
- make remaining header and homepage URL assertions locale-aware
- select the exact Japanese copy action instead of also matching its variant
- serialize API-key tests that mutate one shared account and constrained key list

## Evidence
The previous staging run reached 126 passing tests. Its five deterministic failures were the two header URLs, homepage URL, and two ambiguous copy-menu locators. API-key create/rename passed on retry but raced while running in parallel.

## Validation
- frontend lint: pass
- frontend typecheck: pass
- frontend tests: 62 passed
- Playwright discovery: pass
- git diff --check: pass