### PR TITLE
test: wait for developer API hydration

### DIFF
--- a/frontend/e2e/pages/DeveloperPage.ts
+++ b/frontend/e2e/pages/DeveloperPage.ts
@@ -27,8 +27,18 @@ export class DeveloperPage {
     this.noKeysMessage = page.getByText('No API keys found');
   }
 
+  private waitForApiResponse(path: string, method: string) {
+    return this.page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === path && response.request().method() === method && response.ok(),
+      { timeout: 15_000 },
+    );
+  }
+
   async goto() {
+    const apiKeysLoaded = this.waitForApiResponse('/v1/auth/api-key/list', 'GET');
     await this.page.goto('/user/developer');
+    await apiKeysLoaded;
   }
 
   async expectLoaded() {
@@ -47,7 +57,9 @@ export class DeveloperPage {
     await this.addApiKeyButton.click();
     await expect(this.createModalNameInput).toBeVisible({ timeout: 5_000 });
     await this.createModalNameInput.fill(name);
+    const keyCreated = this.waitForApiResponse('/v1/auth/api-key/create', 'POST');
     await this.createModalSubmit.click();
+    await keyCreated;
     await expect(this.keyCreatedAlert).toBeVisible({ timeout: 10_000 });
   }
 
@@ -62,12 +74,16 @@ export class DeveloperPage {
     await expect(this.renameModalNameInput).toBeVisible({ timeout: 5_000 });
     await this.renameModalNameInput.clear();
     await this.renameModalNameInput.fill(newName);
+    const keyRenamed = this.waitForApiResponse('/v1/auth/api-key/update', 'POST');
     await this.renameModalSubmit.click();
+    await keyRenamed;
   }
 
   async deactivateApiKey(row: Locator) {
     await this.openOptionsMenu(row);
+    const keyDeactivated = this.waitForApiResponse('/v1/auth/api-key/update', 'POST');
     await row.locator('a', { hasText: 'Deactivate' }).dispatchEvent('click');
+    await keyDeactivated;
     await expect(this.keyDeactivatedAlert).toBeVisible({ timeout: 10_000 });
   }
 }


### PR DESCRIPTION
## Summary
- wait for the initial API-key list response before interacting with the SSR-rendered developer module
- synchronize create, rename, and deactivate actions with their successful HTTP responses
- keep persistent row/alert assertions after network completion

## Evidence
The green staging trace showed the failed click happened while the developer chunks and initial `/v1/auth/api-key/list` request were still incomplete (`status: -1`). No create POST was emitted; the SSR button was visible before hydration attached its handler.

## Validation
- frontend lint: pass
- frontend typecheck: pass
- frontend tests: 62 passed
- Playwright discovery: pass
- git diff --check: pass