### PR TITLE
fix(ci): build backend image without stale patches copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Install dependencies
         run: cd backend && bun install --frozen-lockfile
 
+      - name: Build backend image
+        run: docker build --file backend/Dockerfile backend
+
       - name: Lint
         run: cd backend && bun run lint:code
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 FROM base AS install
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY package.json bun.lock ./
-COPY patches ./patches
 RUN bun install --frozen-lockfile
 
 FROM node:22-slim AS release


### PR DESCRIPTION
## Root cause
The backend security upgrade removed the last patched dependency and therefore the tracked `backend/patches` directory. The backend Dockerfile still copied that directory unconditionally, so staging failed before deployment with `COPY failed: stat patches: file does not exist`.

## Fix
- remove the stale `COPY patches ./patches` instruction
- add a backend-image build gate to PR CI using the same `backend` context as staging and production

## Validation
- reproduced the original failure locally with `docker build --target install --file Dockerfile .`
- the same install-stage build passes after the fix
- full backend image build passes and produces `nadeshiko-backend:docker-patches-fix`
- `git diff --check` passes

The failed staging run never reached deployment, so the previous staging backend remained intact.