### PR TITLE
chore(deps): update Nadeshiko SDK consumers to 2.2.2

### DIFF
--- a/discord/bun.lock
+++ b/discord/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "nadeshiko-discord",
       "dependencies": {
-        "@brigadasos/nadeshiko-sdk": "2.1.0-internal",
+        "@brigadasos/nadeshiko-sdk": "2.2.2",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
@@ -49,7 +49,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
-    "@brigadasos/nadeshiko-sdk": ["@brigadasos/nadeshiko-sdk@2.1.0-internal", "", {}, "sha512-3uhbZt/9s1mE8RvmykCTjjUw9lwUDqVyIjIF3Cpq5EFtdRSUVTn/ogkhMOz4vn9K/mkMqmaJ0GJEiB3ih/sW/g=="],
+    "@brigadasos/nadeshiko-sdk": ["@brigadasos/nadeshiko-sdk@2.2.2", "", {}, "sha512-pSYRmLaweRO/6SEPm+qURJXOHAuW2zSnxNymJYGhiXyJaqAivVFJ0FDyfxAtF+aJF+xWchvEbfbqakL1XbgeFg=="],
 
     "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
 

--- a/discord/package.json
+++ b/discord/package.json
@@ -12,7 +12,7 @@
   },
   "license": "AGPL-3.0",
   "dependencies": {
-    "@brigadasos/nadeshiko-sdk": "2.1.0-internal",
+    "@brigadasos/nadeshiko-sdk": "2.2.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",

--- a/discord/src/api.ts
+++ b/discord/src/api.ts
@@ -6,7 +6,7 @@ import type {
   SearchResponse as SdkSearchResponse,
   GetSegmentContextResponse as SdkGetSegmentContextResponse,
   GetStatsOverviewResponse,
-  SearchStatsResponse as SdkSearchStatsResponse,
+  GetSearchStatsResponse as SdkSearchStatsResponse,
 } from '@brigadasos/nadeshiko-sdk';
 import { BOT_CONFIG } from './config';
 import { createLogger } from './logger';

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "nuxt-app",
       "dependencies": {
-        "@brigadasos/nadeshiko-sdk": "2.2.0-internal.fce7d00",
+        "@brigadasos/nadeshiko-sdk": "2.2.2-internal.8b055f5",
         "@grafana/faro-transport-otlp-http": "^2.7.1",
         "@grafana/faro-web-sdk": "^2.7.0",
         "@grafana/faro-web-tracing": "^2.7.1",
@@ -133,7 +133,7 @@
 
     "@bomb.sh/tab": ["@bomb.sh/tab@0.0.15", "", { "peerDependencies": { "cac": "^6.7.14", "citty": "^0.1.6 || ^0.2.0", "commander": "^13.1.0" }, "optionalPeers": ["cac", "citty", "commander"], "bin": { "tab": "dist/bin/cli.mjs" } }, "sha512-Y90ub44TAvbdO9P8mcD/XPyQjFhiR5xmd4Fk7JErmWmEWEUimNnjWiBrVZ16Tj3GA1rLZ+uvCN2V/pzLawv31g=="],
 
-    "@brigadasos/nadeshiko-sdk": ["@brigadasos/nadeshiko-sdk@2.2.0-internal.fce7d00", "", {}, "sha512-rJ5dSEjk++SOZrTOludAsaPWZy3XmVBOIRoWW+57QqfalESe6uiTkf9tybvzsqhiwe9dBvaDkVbveAFMCVcN9g=="],
+    "@brigadasos/nadeshiko-sdk": ["@brigadasos/nadeshiko-sdk@2.2.2-internal.8b055f5", "", {}, "sha512-LCrhVhcQ6+GXw6O9vaS7IX817MuxtWC2PJxKiSPykK8EiZ/4dj+BKFajsnRPddci7Sn/3k5cVVrJXCnZMqqW7g=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "setup": "bun run bin/setup.ts"
   },
   "dependencies": {
-    "@brigadasos/nadeshiko-sdk": "2.2.0-internal.fce7d00",
+    "@brigadasos/nadeshiko-sdk": "2.2.2-internal.8b055f5",
     "@grafana/faro-transport-otlp-http": "^2.7.1",
     "@grafana/faro-web-sdk": "^2.7.0",
     "@grafana/faro-web-tracing": "^2.7.1",


### PR DESCRIPTION
## Summary
- update frontend to the SHA-pinned internal SDK `2.2.2-internal.8b055f5` because it consumes `x-internal` endpoints
- update Discord to the stable public SDK `2.2.2`
- use the generated `GetSearchStatsResponse` operation response type exported by the stable SDK

## Validation
- frontend: frozen install, lint, typecheck, 62 tests, production build
- Discord: frozen install, lint, typecheck, 10 flow tests
- `git diff --check`