### PR TITLE
chore(deps): update Nahkies OpenAPI generator and runtime

### DIFF
--- a/backend/bin/generateOutputTypes.ts
+++ b/backend/bin/generateOutputTypes.ts
@@ -176,14 +176,29 @@ function analyzeRouteFile(filePath: string): RouteFileInfo {
   const bodyTypeReplacements = new Map<string, string>();
   const queryTypeReplacements = new Map<string, string>();
 
-  // Build replacement map from schema assignments
+  // Build replacement map from legacy schema assignments (generator <= 0.22).
   for (const assignment of schemaAssignments) {
     bodyTypeReplacements.set(assignment.inputTypeName, assignment.outputTypeName);
   }
 
-  // Find query type imports: t_XQuerySchema (these don't have schema assignments)
-  const queryTypeRegex = /t_(\w+)QuerySchema/g;
+  // Generator >= 0.23 inlines named schemas directly in parseRequestInput
+  // and uses the model input type in Params (for example t_SearchRequest).
+  // Map those input types back to z.output types, where defaults are applied.
+  const parsedBodySchemaRegex = /body:\s*parseRequestInput\(\s*s_(\w+)\s*,/g;
   let match;
+  while ((match = parsedBodySchemaRegex.exec(content)) !== null) {
+    const baseName = match[1];
+    bodyTypeReplacements.set(`t_${baseName}`, `${baseName}Output`);
+  }
+
+  const parsedQuerySchemaRegex = /query:\s*parseRequestInput\(\s*s_(\w+)\s*,/g;
+  while ((match = parsedQuerySchemaRegex.exec(content)) !== null) {
+    const baseName = match[1];
+    queryTypeReplacements.set(`t_${baseName}`, `${baseName}Output`);
+  }
+
+  // Find legacy inline query type imports: t_XQuerySchema.
+  const queryTypeRegex = /t_(\w+)QuerySchema/g;
   while ((match = queryTypeRegex.exec(content)) !== null) {
     const baseName = match[1];
     // t_FetchMediaInfoQuerySchema -> FetchMediaInfoQueryOutput

--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -8,7 +8,7 @@
         "@aws-sdk/client-sesv2": "^3.1044.0",
         "@better-auth/api-key": "^1.6.25",
         "@elastic/elasticsearch": "^8.19.1",
-        "@nahkies/typescript-express-runtime": "0.22.0",
+        "@nahkies/typescript-express-runtime": "0.26.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/core": "^2.10.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
@@ -44,7 +44,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
-        "@nahkies/openapi-code-generator": "0.22.0",
+        "@nahkies/openapi-code-generator": "0.26.0",
         "@redocly/cli": "^2.30.2",
         "@types/bun": "^1.3.13",
         "@types/express": "^5.0.6",
@@ -251,9 +251,9 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
-    "@biomejs/js-api": ["@biomejs/js-api@3.0.0", "", { "peerDependencies": { "@biomejs/wasm-bundler": "^2.2.0", "@biomejs/wasm-nodejs": "^2.2.0", "@biomejs/wasm-web": "^2.2.0" }, "optionalPeers": ["@biomejs/wasm-bundler", "@biomejs/wasm-nodejs", "@biomejs/wasm-web"] }, "sha512-5QcGJFj9IO+yXl76ICjvkdE38uxRcTDsBzcCZHEZ+ma+Te/nbvJg4A3KtAds9HCrEF0JKLWiyjMhAbqazuJvYA=="],
+    "@biomejs/js-api": ["@biomejs/js-api@4.0.0", "", { "peerDependencies": { "@biomejs/wasm-bundler": "^2.3.0", "@biomejs/wasm-nodejs": "^2.3.0", "@biomejs/wasm-web": "^2.3.0" }, "optionalPeers": ["@biomejs/wasm-bundler", "@biomejs/wasm-nodejs", "@biomejs/wasm-web"] }, "sha512-EOArR/6drRzM1/hwOIz1pZw90FL31Ud4Y7hEHGWVtMNmAwS9SrwZ8hMENGlLVXCeGW/kL46p8kX7eO6x9Nmezg=="],
 
-    "@biomejs/wasm-nodejs": ["@biomejs/wasm-nodejs@2.2.6", "", {}, "sha512-lUEcvW+2eyMTgCofknBT04AvY7KkQSqKe3Nv40+ZxWVlStsPB0v2RWLu7xks69Yxcb3TfNGsfq21OWkdrmO2NQ=="],
+    "@biomejs/wasm-nodejs": ["@biomejs/wasm-nodejs@2.4.15", "", {}, "sha512-5mfoUf66sFwBkR9T82KRxapviesSadJH+qH4+w06gge87sYwjLKTXw4rxGOiJkUTCRtxCuMSUT9VO6VAqhsmkg=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
@@ -357,9 +357,9 @@
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
-    "@nahkies/openapi-code-generator": ["@nahkies/openapi-code-generator@0.22.0", "", { "dependencies": { "@biomejs/biome": "2.2.6", "@biomejs/js-api": "3.0.0", "@biomejs/wasm-nodejs": "2.2.6", "@commander-js/extra-typings": "^14.0.0", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "ajv-formats": "^3.0.1", "commander": "^14.0.1", "js-yaml": "^4.1.0", "json5": "^2.2.3", "lodash": "^4.17.21", "tslib": "^2.8.1", "typescript": "^5.9.3", "zod": "^3.25.74" }, "peerDependencies": { "@typespec/compiler": "^1.1.0", "@typespec/events": "^0.72.1", "@typespec/http": "^1.1.0", "@typespec/openapi": "^1.1.0", "@typespec/openapi3": "^1.1.0", "@typespec/rest": "^0.72.1", "@typespec/sse": "^0.72.1", "@typespec/streams": "^0.72.1", "@typespec/versioning": "^0.72.1", "@typespec/xml": "^0.72.1" }, "optionalPeers": ["@typespec/compiler", "@typespec/events", "@typespec/http", "@typespec/openapi", "@typespec/openapi3", "@typespec/rest", "@typespec/sse", "@typespec/streams", "@typespec/versioning", "@typespec/xml"], "bin": { "openapi-code-generator": "dist/cli.js" } }, "sha512-/jXZRo9PuB/XWaTt8nKy64jaXPqnedmYTqdZfqq9DfApsPZaybqFYpO3EH3cLCId2mzVGd3XOkw0Gk+obsGSJg=="],
+    "@nahkies/openapi-code-generator": ["@nahkies/openapi-code-generator@0.26.0", "", { "dependencies": { "@biomejs/biome": "2.4.15", "@biomejs/js-api": "4.0.0", "@biomejs/wasm-nodejs": "2.4.15", "@commander-js/extra-typings": "^14.0.0", "ajv": "^8.20.0", "ajv-draft-04": "^1.0.0", "ajv-formats": "^3.0.1", "commander": "^14.0.3", "js-yaml": "^4.1.1", "json5": "^2.2.3", "lodash": "^4.18.1", "tslib": "^2.8.1", "typescript": "^6.0.3", "zod": "^4.3.6" }, "peerDependencies": { "@typespec/compiler": "^1.12.0", "@typespec/events": "^0.82.0", "@typespec/http": "^1.12.0", "@typespec/openapi": "^1.12.0", "@typespec/openapi3": "^1.12.0", "@typespec/rest": "^0.82.0", "@typespec/sse": "^0.82.0", "@typespec/streams": "^0.82.0", "@typespec/versioning": "^0.82.0", "@typespec/xml": "^0.82.0", "prettier": "^3.8.3" }, "optionalPeers": ["@typespec/compiler", "@typespec/events", "@typespec/http", "@typespec/openapi", "@typespec/openapi3", "@typespec/rest", "@typespec/sse", "@typespec/streams", "@typespec/versioning", "@typespec/xml", "prettier"], "bin": { "openapi-code-generator": "./bin/cli.mjs" } }, "sha512-SCHak7vvNs1jyASz/m41wsOpGsvGNq3utNzbbb0yMCD9+xLPoVuvgZL3tyil0bJ2LTEeIjqN6ZSF4GUPib8JWQ=="],
 
-    "@nahkies/typescript-express-runtime": ["@nahkies/typescript-express-runtime@0.22.0", "", { "dependencies": { "tslib": "^2.8.1" }, "peerDependencies": { "@types/body-parser": "^1.19.6", "@types/cors": "^2.8.19", "body-parser": "^2.2.0", "cors": "^2.8.5", "express": "^5.1.0", "joi": "^17.13.3 || ^18.0.1", "zod": "^3.25.74 || ^4.1.12" }, "optionalPeers": ["cors", "joi", "zod"] }, "sha512-feqC/h0HNixZZki0L8CVeCf8uGRjYJrqzTs/b+xryIViLI3KzQ90F0pbQ4m/ZzRsqGfaR7YTTJ9GNmXJkx5EjQ=="],
+    "@nahkies/typescript-express-runtime": ["@nahkies/typescript-express-runtime@0.26.0", "", { "dependencies": { "raw-body": "^3.0.2", "tslib": "^2.8.1" }, "peerDependencies": { "@types/body-parser": "^1.19.6", "@types/cors": "^2.8.19", "body-parser": "^2.2.0", "cors": "^2.8.5", "express": "^5.1.0", "joi": "^17.13.3 || ^18.0.1", "zod": "^3.25.74 || ^4.1.12" }, "optionalPeers": ["joi", "zod"] }, "sha512-whyGaL42S62YZpqeuD+pWA3TJxOV0ksjT6IirMA4t8k78NmN7DiKzrhFLRoE/AatHej3n0KggE/TNeRulK1VBA=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
@@ -659,7 +659,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
 
@@ -1137,7 +1137,7 @@
 
     "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
-    "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
 
@@ -1951,13 +1951,7 @@
 
     "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome": ["@biomejs/biome@2.2.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.2.6", "@biomejs/cli-darwin-x64": "2.2.6", "@biomejs/cli-linux-arm64": "2.2.6", "@biomejs/cli-linux-arm64-musl": "2.2.6", "@biomejs/cli-linux-x64": "2.2.6", "@biomejs/cli-linux-x64-musl": "2.2.6", "@biomejs/cli-win32-arm64": "2.2.6", "@biomejs/cli-win32-x64": "2.2.6" }, "bin": { "biome": "bin/biome" } }, "sha512-yKTCNGhek0rL5OEW1jbLeZX8LHaM8yk7+3JRGv08my+gkpmtb5dDE+54r2ZjZx0ediFEn1pYBOJSmOdDP9xtFw=="],
-
-    "@nahkies/openapi-code-generator/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
-
-    "@nahkies/openapi-code-generator/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
-    "@nahkies/openapi-code-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
 
     "@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
@@ -2097,17 +2091,27 @@
 
     "@usebruno/cli/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "@usebruno/cli/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+
     "@usebruno/cli/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "@usebruno/converters/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@usebruno/converters/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "@usebruno/converters/nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 
     "@usebruno/filestore/ajv": ["@redocly/ajv@8.18.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA=="],
 
+    "@usebruno/filestore/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+
     "@usebruno/filestore/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
+    "@usebruno/js/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
     "@usebruno/js/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
+
+    "@usebruno/js/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "@usebruno/js/nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 
@@ -2117,11 +2121,15 @@
 
     "@usebruno/lang/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
+    "@usebruno/lang/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+
     "@usebruno/requests/@faker-js/faker": ["@faker-js/faker@9.9.0", "", {}, "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA=="],
 
     "@usebruno/requests/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "@usebruno/schema/nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
+
+    "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "apache-arrow/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
 
@@ -2142,6 +2150,8 @@
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "grpc-js-reflection-client/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
@@ -2190,6 +2200,8 @@
     "util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "yup/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "@aws-crypto/sha256-browser/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw=="],
 
@@ -2377,21 +2389,21 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UZPmn3M45CjTYulgcrFJFZv7YmK3pTxTJDrFYlNElT2FNnkkX4fsxjExTSMeWKQYoZjvekpH5cvrYZZlWu3yfA=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-HOUIquhHVgh/jvxyClpwlpl/oeMqntlteL89YqjuFDiZ091P0vhHccwz+8muu3nTyHWM5FQslt+4Jdcd67+xWQ=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-BpGtuMJGN+o8pQjvYsUKZ+4JEErxdSmcRD/JG3mXoWc6zrcA7OkuyGFN1mDggO0Q1n7qXxo/PcupHk8gzijt5g=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-TjCenQq3N6g1C+5UT3jE1bIiJb5MWQvulpUngTIpFsL4StVAUXucWD0SL9MCW89Tm6awWfeXBbZBAhJwjyFbRQ=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1HaM/dpI/1Z68zp8ZdT6EiBq+/O/z97a2AiHMl+VAdv5/ELckFt9EvRb8hDHpk8hUMoz03gXkC7VPXOVtU7faA=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1ZcBux8zVM3JhWN2ZCPaYf0+ogxXG316uaoXJdgoPZcdK/rmRcRY7PqHdAos2ExzvjIdvhQp72UcveI98hgOog=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-h3A88G8PGM1ryTeZyLlSdfC/gz3e95EJw9BZmA6Po412DRqwqPBa2Y9U+4ZSGUAXCsnSQE00jLV8Pyrh0d+jQw=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
 
-    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-yx0CqeOhPjYQ5ZXgPfu8QYkgBhVJyvWe36as7jRuPrKPO5ylVDfwVtPQ+K/mooNTADW0IhxOZm3aPu16dP8yNQ=="],
+    "@nahkies/openapi-code-generator/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA=="],
 

--- a/backend/generated/models.ts
+++ b/backend/generated/models.ts
@@ -4,6 +4,11 @@
 
 export type t_ActivityType = 'SEARCH' | 'ANKI_EXPORT' | 'SEGMENT_PLAY' | 'SHARE';
 
+export type t_AddSegmentToCollectionRequest = {
+  note?: string;
+  segmentPublicId: string;
+};
+
 export type t_AdminReportGroup = {
   firstReportedAt: string;
   lastStatusChange: string | null;
@@ -40,6 +45,40 @@ export type t_Announcement = {
   type: 'INFO' | 'WARNING' | 'MAINTENANCE';
 };
 
+export type t_BatchUpdateReportsRequest = {
+  adminNotes?: string;
+  ids: number[];
+  status: t_ReportStatus;
+};
+
+export type t_BulkDeleteReportsRequest = {
+  filters?: {
+    auditRunId?: number;
+    orphaned?: boolean;
+    source?: t_ReportSource;
+    status?: string;
+    targetEpisodeNumber?: number;
+    targetMediaId?: number;
+    targetSegmentId?: number;
+    targetType?: t_ReportTargetType;
+  };
+};
+
+export type t_BulkUpdateReportsRequest = {
+  adminNotes?: string;
+  filters?: {
+    auditRunId?: number;
+    orphaned?: boolean;
+    source?: t_ReportSource;
+    status?: string;
+    targetEpisodeNumber?: number;
+    targetMediaId?: number;
+    targetSegmentId?: number;
+    targetType?: t_ReportTargetType;
+  };
+  status: t_ReportStatus;
+};
+
 export type t_Category = 'ANIME' | 'JDRAMA' | 'YOUTUBE';
 
 export type t_CategoryCount = {
@@ -58,9 +97,19 @@ export type t_Collection = {
   visibility: t_CollectionVisibility;
 };
 
+export type t_CollectionCreateRequest = {
+  name: string;
+  visibility?: t_CollectionVisibility;
+};
+
 export type t_CollectionListResponse = {
   collections: t_Collection[];
   pagination: t_CursorPagination;
+};
+
+export type t_CollectionUpdateRequest = {
+  name?: string;
+  visibility?: t_CollectionVisibility;
 };
 
 export type t_CollectionVisibility = 'PUBLIC' | 'PRIVATE';
@@ -83,11 +132,36 @@ export type t_CoveredWordsResponse = {
   words: t_CoveredWord[];
 };
 
+export type t_CoveredWordsUpdateRequest = {
+  maxRank?: number;
+  onlyUncovered?: boolean;
+};
+
 export type t_CoveredWordsUpdateResponse = {
   newlyCovered: number;
   percentage: number;
   totalCovered: number;
   wordsChecked: number;
+};
+
+export type t_CreateReportRequest = {
+  description?: string;
+  reason:
+    | 'WRONG_TRANSLATION'
+    | 'WRONG_TIMING'
+    | 'WRONG_AUDIO'
+    | 'WRONG_JAPANESE_TEXT'
+    | 'LOW_QUALITY_AUDIO'
+    | 'NSFW_NOT_TAGGED'
+    | 'DUPLICATE_SEGMENT'
+    | 'WRONG_TITLE'
+    | 'DUPLICATE_MEDIA'
+    | 'WRONG_EPISODE_NUMBER'
+    | 'IMAGE_ISSUE'
+    | 'MISSING_EPISODES'
+    | 'INAPPROPRIATE_CONTENT'
+    | 'OTHER';
+  target: t_UserReportTarget;
 };
 
 export type t_CursorPagination = {
@@ -109,17 +183,38 @@ export type t_Episode = {
   titleRomaji: string | null;
 };
 
+export type t_EpisodeCreateRequest = {
+  airedAt?: string;
+  description?: string;
+  episodeNumber: number;
+  externalVideoId?: string;
+  lengthSeconds?: number;
+  thumbnailUrl?: string;
+  titleEn?: string;
+  titleJa?: string;
+  titleRomaji?: string;
+};
+
 export type t_EpisodeListResponse = {
   episodes: t_Episode[];
   pagination: t_CursorPagination;
 };
 
+export type t_EpisodeUpdateRequest = {
+  airedAt?: string;
+  description?: string;
+  externalVideoId?: string;
+  lengthSeconds?: number;
+  thumbnailUrl?: string;
+  titleEn?: string;
+  titleJa?: string;
+  titleRomaji?: string;
+};
+
 export type t_Error400 = {
   code: 'VALIDATION_FAILED' | 'INVALID_JSON' | 'INVALID_REQUEST';
   detail: string;
-  errors?: {
-    [key: string]: string | undefined;
-  };
+  errors?: Record<string, string>;
   instance?: string;
   status: 400;
   title: string;
@@ -129,9 +224,7 @@ export type t_Error400 = {
 export type t_Error401 = {
   code: 'AUTH_CREDENTIALS_REQUIRED' | 'AUTH_CREDENTIALS_INVALID' | 'AUTH_CREDENTIALS_EXPIRED';
   detail: string;
-  errors?: {
-    [key: string]: string | undefined;
-  };
+  errors?: Record<string, string>;
   instance?: string;
   status: 401;
   title: string;
@@ -141,9 +234,7 @@ export type t_Error401 = {
 export type t_Error403 = {
   code: 'ACCESS_DENIED' | 'INSUFFICIENT_PERMISSIONS';
   detail: string;
-  errors?: {
-    [key: string]: string | undefined;
-  };
+  errors?: Record<string, string>;
   instance?: string;
   status: 403;
   title: string;
@@ -153,9 +244,7 @@ export type t_Error403 = {
 export type t_Error404 = {
   code: 'NOT_FOUND';
   detail: string;
-  errors?: {
-    [key: string]: string | undefined;
-  };
+  errors?: Record<string, string>;
   instance?: string;
   status: 404;
   title: string;
@@ -165,9 +254,7 @@ export type t_Error404 = {
 export type t_Error409 = {
   code: 'ACCOUNT_CONFLICT' | 'DUPLICATE_KEY';
   detail: string;
-  errors?: {
-    [key: string]: string | undefined;
-  };
+  errors?: Record<string, string>;
   instance?: string;
   status: 409;
   title: string;
@@ -177,9 +264,7 @@ export type t_Error409 = {
 export type t_Error429 = {
   code: 'RATE_LIMIT_EXCEEDED' | 'QUOTA_EXCEEDED';
   detail: string;
-  errors?: {
-    [key: string]: string | undefined;
-  };
+  errors?: Record<string, string>;
   instance?: string;
   status: 429;
   title: string;
@@ -189,9 +274,7 @@ export type t_Error429 = {
 export type t_Error500 = {
   code: 'INTERNAL_SERVER_EXCEPTION';
   detail: string;
-  errors?: {
-    [key: string]: string | undefined;
-  };
+  errors?: Record<string, string>;
   instance?: string;
   status: 500;
   title: string;
@@ -250,9 +333,7 @@ export type t_MediaAudit = {
   } | null;
   name: string;
   targetType: 'MEDIA' | 'EPISODE';
-  threshold: {
-    [key: string]: unknown | undefined;
-  };
+  threshold: Record<string, unknown>;
   thresholdSchema: {
     default: number | boolean;
     key: string;
@@ -270,13 +351,31 @@ export type t_MediaAuditRun = {
   createdAt: string;
   id: number;
   resultCount: number;
-  thresholdUsed: {
-    [key: string]: unknown | undefined;
-  };
+  thresholdUsed: Record<string, unknown>;
 };
 
 export type t_MediaAutocompleteResponse = {
   media: t_MediaSummary[];
+};
+
+export type t_MediaCreateRequest = {
+  airingFormat: 'TV' | 'MOVIE' | 'OVA' | 'ONA' | 'SPECIAL' | 'YOUTUBE';
+  airingStatus: 'FINISHED' | 'RELEASING' | 'NOT_YET_RELEASED' | 'CANCELLED';
+  category: t_Category;
+  endDate?: string;
+  externalIds?: t_ExternalId;
+  genres: string[];
+  hashSalt: string;
+  nameEn: string;
+  nameJa: string;
+  nameRomaji: string;
+  seasonName: 'WINTER' | 'SPRING' | 'SUMMER' | 'FALL' | 'NONE';
+  seasonYear: number;
+  startDate: string;
+  storage: 'LOCAL' | 'R2';
+  storageBasePath?: string;
+  studio?: string | null;
+  version: string;
 };
 
 export type t_MediaFilterItem = {
@@ -315,13 +414,32 @@ export type t_MediaSummary = {
   slug: string;
 };
 
+export type t_MediaUpdateRequest = {
+  airingFormat?: 'TV' | 'MOVIE' | 'OVA' | 'ONA' | 'SPECIAL' | 'YOUTUBE';
+  airingStatus?: 'FINISHED' | 'RELEASING' | 'NOT_YET_RELEASED' | 'CANCELLED';
+  category?: t_Category;
+  endDate?: string | null;
+  externalIds?: t_ExternalId;
+  genres?: string[];
+  hashSalt?: string;
+  nameEn?: string;
+  nameJa?: string;
+  nameRomaji?: string;
+  seasonName?: 'WINTER' | 'SPRING' | 'SUMMER' | 'FALL' | 'NONE';
+  seasonYear?: number;
+  segmentCount?: number;
+  startDate?: string;
+  storage?: 'LOCAL' | 'R2';
+  storageBasePath?: string;
+  studio?: string | null;
+  version?: string;
+};
+
 export type t_Report = {
   adminNotes: string | null;
   auditRunId: number | null;
   createdAt: string;
-  data: {
-    [key: string]: unknown | undefined;
-  } | null;
+  data: Record<string, unknown> | null;
   description: string | null;
   id: number;
   reason: t_ReportReason;
@@ -429,16 +547,26 @@ export type t_SearchMediaFilters = {
   category?: t_Category[];
 };
 
+export type t_SearchMediaRequest = {
+  filters?: t_SearchMediaFilters;
+  query: string;
+  take?: number;
+};
+
 export type t_SearchMultipleQuery = {
   exactMatch?: boolean;
   words: string[];
 };
 
+export type t_SearchMultipleRequest = {
+  filters?: t_SearchFilters;
+  include?: t_IncludeExpansion[];
+  query: t_SearchMultipleQuery;
+};
+
 export type t_SearchMultipleResponse = {
   includes?: {
-    media?: {
-      [key: string]: t_Media | undefined;
-    };
+    media?: Record<string, t_Media>;
   };
   results: t_WordMatch[];
 };
@@ -455,11 +583,18 @@ export type t_SearchQuery = {
   search?: string;
 };
 
+export type t_SearchRequest = {
+  cursor?: string;
+  filters?: t_SearchFilters;
+  include?: t_IncludeExpansion[];
+  query?: t_SearchQuery;
+  sort?: t_SearchSort;
+  take?: number;
+};
+
 export type t_SearchResponse = {
   includes?: {
-    media?: {
-      [key: string]: t_Media | undefined;
-    };
+    media?: Record<string, t_Media>;
   };
   pagination: t_SearchPagination;
   segments: t_Segment[];
@@ -470,12 +605,16 @@ export type t_SearchSort = {
   seed?: number;
 };
 
+export type t_SearchStatsRequest = {
+  filters?: t_SearchFilters;
+  include?: t_IncludeExpansion[];
+  query?: t_SearchQuery;
+};
+
 export type t_SearchStatsResponse = {
   categories: t_CategoryCount[];
   includes?: {
-    media?: {
-      [key: string]: t_Media | undefined;
-    };
+    media?: Record<string, t_Media>;
   };
   media: t_MediaSearchStats[];
 };
@@ -512,11 +651,13 @@ export type t_Segment = {
   };
 };
 
+export type t_SegmentBatchCreateRequest = {
+  segments: t_SegmentCreateRequest[];
+};
+
 export type t_SegmentContextResponse = {
   includes?: {
-    media?: {
-      [key: string]: t_Media | undefined;
-    };
+    media?: Record<string, t_Media>;
   };
   segments: t_Segment[];
 };
@@ -525,13 +666,9 @@ export type t_SegmentCreateRequest = {
   contentRating?: t_ContentRating;
   endTimeMs: number;
   hashedId: string;
-  posAnalysis?: {
-    [key: string]: unknown | undefined;
-  } | null;
+  posAnalysis?: Record<string, unknown> | null;
   position: number;
-  ratingAnalysis?: {
-    [key: string]: unknown | undefined;
-  } | null;
+  ratingAnalysis?: Record<string, unknown> | null;
   startTimeMs: number;
   status?: t_SegmentStatus;
   storage: 'LOCAL' | 'R2';
@@ -550,12 +687,8 @@ export type t_SegmentCreateRequest = {
 
 export type t_SegmentInternal = t_Segment & {
   hashedId?: string | null;
-  posAnalysis?: {
-    [key: string]: unknown | undefined;
-  } | null;
-  ratingAnalysis?: {
-    [key: string]: unknown | undefined;
-  } | null;
+  posAnalysis?: Record<string, unknown> | null;
+  ratingAnalysis?: Record<string, unknown> | null;
   storage?: 'LOCAL' | 'R2' | null;
   storageBasePath?: string | null;
 };
@@ -569,13 +702,34 @@ export type t_SegmentRevision = {
   createdAt: string;
   id: number;
   revisionNumber: number;
-  snapshot: {
-    [key: string]: unknown | undefined;
-  };
+  snapshot: Record<string, unknown>;
   userName?: string | null;
 };
 
 export type t_SegmentStatus = 'ACTIVE' | 'HIDDEN' | 'DELETED';
+
+export type t_SegmentUpdateRequest = {
+  contentRating?: t_ContentRating;
+  endTimeMs?: number;
+  hashedId?: string;
+  posAnalysis?: Record<string, unknown> | null;
+  position?: number;
+  ratingAnalysis?: Record<string, unknown> | null;
+  startTimeMs?: number;
+  status?: t_SegmentStatus;
+  storage?: 'LOCAL' | 'R2';
+  textEn?: {
+    content?: string;
+    isMachineTranslated?: boolean;
+  };
+  textEs?: {
+    content?: string;
+    isMachineTranslated?: boolean;
+  };
+  textJa?: {
+    content?: string;
+  };
+};
 
 export type t_StatsOverview = {
   dialogueHours: number;
@@ -607,6 +761,16 @@ export type t_Token = {
   s: string;
 };
 
+export type t_UpdateCollectionSegmentRequest = {
+  note?: string | null;
+  position?: number;
+};
+
+export type t_UpdateReportRequest = {
+  adminNotes?: string;
+  status?: t_ReportStatus;
+};
+
 export type t_UserActivity = {
   activityType: t_ActivityType;
   createdAt: string;
@@ -616,6 +780,15 @@ export type t_UserActivity = {
   mediaPublicId: string | null;
   searchQuery: string | null;
   segmentPublicId: string | null;
+};
+
+export type t_UserActivityRequest = {
+  activityType: 'SEARCH' | 'SEGMENT_PLAY' | 'SHARE' | 'ANKI_EXPORT';
+  japaneseText?: string;
+  mediaName?: string;
+  mediaPublicId?: string;
+  searchQuery?: string;
+  segmentPublicId?: string;
 };
 
 export type t_UserActivityStats = {
@@ -725,7 +898,7 @@ export type t_WordMatchMedia = {
   mediaPublicId: string;
 };
 
-export type t_AddExcludedMediaRequestBodySchema = {
+export type t_AddExcludedMediaRequestBody = {
   mediaPublicId: string;
 };
 
@@ -733,84 +906,8 @@ export type t_AddSegmentToCollectionParamSchema = {
   collectionPublicId: string;
 };
 
-export type t_AddSegmentToCollectionRequestBodySchema = {
-  note?: string;
-  segmentPublicId: string;
-};
-
-export type t_BatchUpdateAdminReportsRequestBodySchema = {
-  adminNotes?: string;
-  ids: number[];
-  status: t_ReportStatus;
-};
-
-export type t_BulkDeleteAdminReportsRequestBodySchema = {
-  filters?: {
-    auditRunId?: number;
-    orphaned?: boolean;
-    source?: t_ReportSource;
-    status?: string;
-    targetEpisodeNumber?: number;
-    targetMediaId?: number;
-    targetSegmentId?: number;
-    targetType?: t_ReportTargetType;
-  };
-};
-
-export type t_BulkUpdateAdminReportsRequestBodySchema = {
-  adminNotes?: string;
-  filters?: {
-    auditRunId?: number;
-    orphaned?: boolean;
-    source?: t_ReportSource;
-    status?: string;
-    targetEpisodeNumber?: number;
-    targetMediaId?: number;
-    targetSegmentId?: number;
-    targetType?: t_ReportTargetType;
-  };
-  status: t_ReportStatus;
-};
-
-export type t_CreateCollectionRequestBodySchema = {
-  name: string;
-  visibility?: t_CollectionVisibility;
-};
-
 export type t_CreateEpisodeParamSchema = {
   mediaPublicId: string;
-};
-
-export type t_CreateEpisodeRequestBodySchema = {
-  airedAt?: string;
-  description?: string;
-  episodeNumber: number;
-  externalVideoId?: string;
-  lengthSeconds?: number;
-  thumbnailUrl?: string;
-  titleEn?: string;
-  titleJa?: string;
-  titleRomaji?: string;
-};
-
-export type t_CreateMediaRequestBodySchema = {
-  airingFormat: 'TV' | 'MOVIE' | 'OVA' | 'ONA' | 'SPECIAL' | 'YOUTUBE';
-  airingStatus: 'FINISHED' | 'RELEASING' | 'NOT_YET_RELEASED' | 'CANCELLED';
-  category: t_Category;
-  endDate?: string;
-  externalIds?: t_ExternalId;
-  genres: string[];
-  hashSalt: string;
-  nameEn: string;
-  nameJa: string;
-  nameRomaji: string;
-  seasonName: 'WINTER' | 'SPRING' | 'SUMMER' | 'FALL' | 'NONE';
-  seasonYear: number;
-  startDate: string;
-  storage: 'LOCAL' | 'R2';
-  storageBasePath?: string;
-  studio?: string | null;
-  version: string;
 };
 
 export type t_CreateSegmentParamSchema = {
@@ -818,60 +915,9 @@ export type t_CreateSegmentParamSchema = {
   mediaPublicId: string;
 };
 
-export type t_CreateSegmentRequestBodySchema = {
-  contentRating?: t_ContentRating;
-  endTimeMs: number;
-  hashedId: string;
-  posAnalysis?: {
-    [key: string]: unknown | undefined;
-  } | null;
-  position: number;
-  ratingAnalysis?: {
-    [key: string]: unknown | undefined;
-  } | null;
-  startTimeMs: number;
-  status?: t_SegmentStatus;
-  storage: 'LOCAL' | 'R2';
-  textEn?: {
-    content?: string;
-    isMachineTranslated?: boolean;
-  };
-  textEs?: {
-    content?: string;
-    isMachineTranslated?: boolean;
-  };
-  textJa: {
-    content?: string;
-  };
-};
-
 export type t_CreateSegmentsBatchParamSchema = {
   episodeNumber: number;
   mediaPublicId: string;
-};
-
-export type t_CreateSegmentsBatchRequestBodySchema = {
-  segments: t_SegmentCreateRequest[];
-};
-
-export type t_CreateUserReportRequestBodySchema = {
-  description?: string;
-  reason:
-    | 'WRONG_TRANSLATION'
-    | 'WRONG_TIMING'
-    | 'WRONG_AUDIO'
-    | 'WRONG_JAPANESE_TEXT'
-    | 'LOW_QUALITY_AUDIO'
-    | 'NSFW_NOT_TAGGED'
-    | 'DUPLICATE_SEGMENT'
-    | 'WRONG_TITLE'
-    | 'DUPLICATE_MEDIA'
-    | 'WRONG_EPISODE_NUMBER'
-    | 'IMAGE_ISSUE'
-    | 'MISSING_EPISODES'
-    | 'INAPPROPRIATE_CONTENT'
-    | 'OTHER';
-  target: t_UserReportTarget;
 };
 
 export type t_DeleteAdminReportParamSchema = {
@@ -934,12 +980,6 @@ export type t_GetEpisodeParamSchema = {
 
 export type t_GetMediaParamSchema = {
   mediaPublicId: string;
-};
-
-export type t_GetSearchStatsRequestBodySchema = {
-  filters?: t_SearchFilters;
-  include?: t_IncludeExpansion[];
-  query?: t_SearchQuery;
 };
 
 export type t_GetSegmentParamSchema = {
@@ -1043,52 +1083,8 @@ export type t_RunAdminMediaAuditQuerySchema = {
   category?: 'ANIME' | 'JDRAMA';
 };
 
-export type t_SearchRequestBodySchema = {
-  cursor?: string;
-  filters?: t_SearchFilters;
-  include?: t_IncludeExpansion[];
-  query?: t_SearchQuery;
-  sort?: t_SearchSort;
-  take?: number;
-};
-
 export type t_SearchCollectionSegmentsParamSchema = {
   collectionPublicId: string;
-};
-
-export type t_SearchCollectionSegmentsRequestBodySchema = {
-  cursor?: string;
-  filters?: t_SearchFilters;
-  include?: t_IncludeExpansion[];
-  query?: t_SearchQuery;
-  sort?: t_SearchSort;
-  take?: number;
-};
-
-export type t_SearchMediaRequestBodySchema = {
-  filters?: t_SearchMediaFilters;
-  query: string;
-  take?: number;
-};
-
-export type t_SearchWordsRequestBodySchema = {
-  filters?: t_SearchFilters;
-  include?: t_IncludeExpansion[];
-  query: t_SearchMultipleQuery;
-};
-
-export type t_TrackUserActivityRequestBodySchema = {
-  activityType: 'SEARCH' | 'SEGMENT_PLAY' | 'SHARE' | 'ANKI_EXPORT';
-  japaneseText?: string;
-  mediaName?: string;
-  mediaPublicId?: string;
-  searchQuery?: string;
-  segmentPublicId?: string;
-};
-
-export type t_TriggerCoveredWordsUpdateRequestBodySchema = {
-  maxRank?: number;
-  onlyUncovered?: boolean;
 };
 
 export type t_UnenrollUserLabParamSchema = {
@@ -1099,35 +1095,17 @@ export type t_UpdateAdminMediaAuditParamSchema = {
   name: string;
 };
 
-export type t_UpdateAdminMediaAuditRequestBodySchema = {
+export type t_UpdateAdminMediaAuditRequestBody = {
   enabled?: boolean;
-  threshold?: {
-    [key: string]: unknown | undefined;
-  };
+  threshold?: Record<string, unknown>;
 };
 
 export type t_UpdateAdminReportParamSchema = {
   reportId: number;
 };
 
-export type t_UpdateAdminReportRequestBodySchema = {
-  adminNotes?: string;
-  status?: t_ReportStatus;
-};
-
-export type t_UpdateAnnouncementRequestBodySchema = {
-  active: boolean;
-  message: string;
-  type: 'INFO' | 'WARNING' | 'MAINTENANCE';
-};
-
 export type t_UpdateCollectionParamSchema = {
   collectionPublicId: string;
-};
-
-export type t_UpdateCollectionRequestBodySchema = {
-  name?: string;
-  visibility?: t_CollectionVisibility;
 };
 
 export type t_UpdateCollectionSegmentParamSchema = {
@@ -1135,111 +1113,15 @@ export type t_UpdateCollectionSegmentParamSchema = {
   segmentPublicId: string;
 };
 
-export type t_UpdateCollectionSegmentRequestBodySchema = {
-  note?: string | null;
-  position?: number;
-};
-
 export type t_UpdateEpisodeParamSchema = {
   episodeNumber: number;
   mediaPublicId: string;
-};
-
-export type t_UpdateEpisodeRequestBodySchema = {
-  airedAt?: string;
-  description?: string;
-  externalVideoId?: string;
-  lengthSeconds?: number;
-  thumbnailUrl?: string;
-  titleEn?: string;
-  titleJa?: string;
-  titleRomaji?: string;
 };
 
 export type t_UpdateMediaParamSchema = {
   mediaPublicId: string;
 };
 
-export type t_UpdateMediaRequestBodySchema = {
-  airingFormat?: 'TV' | 'MOVIE' | 'OVA' | 'ONA' | 'SPECIAL' | 'YOUTUBE';
-  airingStatus?: 'FINISHED' | 'RELEASING' | 'NOT_YET_RELEASED' | 'CANCELLED';
-  category?: t_Category;
-  endDate?: string | null;
-  externalIds?: t_ExternalId;
-  genres?: string[];
-  hashSalt?: string;
-  nameEn?: string;
-  nameJa?: string;
-  nameRomaji?: string;
-  seasonName?: 'WINTER' | 'SPRING' | 'SUMMER' | 'FALL' | 'NONE';
-  seasonYear?: number;
-  segmentCount?: number;
-  startDate?: string;
-  storage?: 'LOCAL' | 'R2';
-  storageBasePath?: string;
-  studio?: string | null;
-  version?: string;
-};
-
 export type t_UpdateSegmentParamSchema = {
   segmentPublicId: string;
-};
-
-export type t_UpdateSegmentRequestBodySchema = {
-  contentRating?: t_ContentRating;
-  endTimeMs?: number;
-  hashedId?: string;
-  posAnalysis?: {
-    [key: string]: unknown | undefined;
-  } | null;
-  position?: number;
-  ratingAnalysis?: {
-    [key: string]: unknown | undefined;
-  } | null;
-  startTimeMs?: number;
-  status?: t_SegmentStatus;
-  storage?: 'LOCAL' | 'R2';
-  textEn?: {
-    content?: string;
-    isMachineTranslated?: boolean;
-  };
-  textEs?: {
-    content?: string;
-    isMachineTranslated?: boolean;
-  };
-  textJa?: {
-    content?: string;
-  };
-};
-
-export type t_UpdateUserPreferencesRequestBodySchema = {
-  ankiProfiles?: {
-    deck?: string | null;
-    fields?: {
-      key: string;
-      value: string;
-    }[];
-    id: string;
-    key?: string | null;
-    model?: string | null;
-    name: string;
-    serverAddress: string;
-  }[];
-  contentRatingPreferences?: {
-    nsfw?: 'SHOW' | 'BLUR' | 'HIDE';
-  };
-  hiddenMedia?: {
-    mediaPublicId: string;
-    nameEn?: string;
-    nameJa?: string;
-    nameRomaji?: string;
-  }[];
-  mediaNameLanguage?: 'ENGLISH' | 'JAPANESE' | 'ROMAJI';
-  searchHistory?: {
-    enabled?: boolean;
-  };
-  translationVisibilityPreferences?: {
-    EN?: 'show' | 'spoiler' | 'hidden';
-    ES?: 'show' | 'spoiler' | 'hidden';
-  };
 };

--- a/backend/generated/outputTypes.ts
+++ b/backend/generated/outputTypes.ts
@@ -105,6 +105,8 @@ export type SegmentListResponseOutput = z.output<typeof schemas.s_SegmentListRes
 export type UserExportCollectionOutput = z.output<typeof schemas.s_UserExportCollection>;
 export type AdminReportListResponseOutput = z.output<typeof schemas.s_AdminReportListResponse>;
 export type UserExportResponseOutput = z.output<typeof schemas.s_UserExportResponse>;
+export type AddExcludedMediaRequestBodyOutput = z.output<typeof schemas.s_AddExcludedMediaRequestBody>;
+export type UpdateAdminMediaAuditRequestBodyOutput = z.output<typeof schemas.s_UpdateAdminMediaAuditRequestBody>;
 
 // ============================================
 // Inline query schemas and their output types
@@ -114,7 +116,7 @@ export const listUserActivityQuerySchema = z.object({
     cursor: z.string().optional(),
     take: z.coerce.number().min(1).max(100).optional().default(20),
     activityType: schemas.s_ActivityType.optional(),
-    date: z.string().optional(),
+    date: z.iso.date().optional(),
   });
 export type ListUserActivityQueryOutput = z.output<typeof listUserActivityQuerySchema>;
 
@@ -123,7 +125,7 @@ export const getUserActivityHeatmapQuerySchema = z.object({
   });
 export type GetUserActivityHeatmapQueryOutput = z.output<typeof getUserActivityHeatmapQuerySchema>;
 
-export const getUserActivityStatsQuerySchema = z.object({ since: z.string().optional() });
+export const getUserActivityStatsQuerySchema = z.object({ since: z.iso.date().optional() });
 export type GetUserActivityStatsQueryOutput = z.output<typeof getUserActivityStatsQuerySchema>;
 
 export const listAdminReportsQuerySchema = z.object({

--- a/backend/generated/routes/activity.ts
+++ b/backend/generated/routes/activity.ts
@@ -2,16 +2,18 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ExpressRuntimeError, RequestInputType } from '@nahkies/typescript-express-runtime/errors';
+import { RequestInputType } from '@nahkies/typescript-express-runtime/errors';
 import {
   type ExpressRuntimeResponder,
   ExpressRuntimeResponse,
+  handleImplementationError,
+  handleResponse,
   type Params,
-  SkipResponse,
+  type SkipResponse,
   type StatusCode,
 } from '@nahkies/typescript-express-runtime/server';
 import { parseRequestInput, responseValidationFactory } from '@nahkies/typescript-express-runtime/zod-v4';
-import { type NextFunction, type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type RequestHandler, type Response, Router } from 'express';
 import { z } from 'zod/v4';
 import type {
   t_CursorPagination,
@@ -60,9 +62,7 @@ export type ListUserActivity = (
 
 export type GetUserActivityHeatmapResponder = {
   with200(): ExpressRuntimeResponse<{
-    activityByDay: {
-      [key: string]: t_HeatmapDayCounts | undefined;
-    };
+    activityByDay: Record<string, t_HeatmapDayCounts>;
   }>;
   with401(): ExpressRuntimeResponse<t_Error401>;
   with403(): ExpressRuntimeResponse<t_Error403>;
@@ -100,14 +100,21 @@ export type ActivityImplementation = {
   getUserActivityStats: GetUserActivityStats;
 };
 
-export function createActivityRouter(implementation: ActivityImplementation): Router {
+export function createActivityRouter(
+  implementation: ActivityImplementation,
+  options: { middleware?: RequestHandler[] } = {},
+): Router {
   const router = Router();
+
+  if (options.middleware?.length) {
+    router.use(...options.middleware);
+  }
 
   const listUserActivityQuerySchema = z.object({
     cursor: z.string().optional(),
     take: z.coerce.number().min(1).max(100).optional().default(20),
     activityType: s_ActivityType.optional(),
-    date: z.string().optional(),
+    date: z.iso.date().optional(),
   });
 
   const listUserActivityResponseBodyValidator = responseValidationFactory(
@@ -155,24 +162,10 @@ export function createActivityRouter(implementation: ActivityImplementation): Ro
         },
       };
 
-      const response = await implementation.listUserActivity(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listUserActivityResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listUserActivity(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listUserActivityResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -206,9 +199,7 @@ export function createActivityRouter(implementation: ActivityImplementation): Ro
       const responder = {
         with200() {
           return new ExpressRuntimeResponse<{
-            activityByDay: {
-              [key: string]: t_HeatmapDayCounts | undefined;
-            };
+            activityByDay: Record<string, t_HeatmapDayCounts>;
           }>(200);
         },
         with401() {
@@ -228,30 +219,16 @@ export function createActivityRouter(implementation: ActivityImplementation): Ro
         },
       };
 
-      const response = await implementation.getUserActivityHeatmap(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getUserActivityHeatmapResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getUserActivityHeatmap(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getUserActivityHeatmapResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
 
-  const getUserActivityStatsQuerySchema = z.object({ since: z.string().optional() });
+  const getUserActivityStatsQuerySchema = z.object({ since: z.iso.date().optional() });
 
   const getUserActivityStatsResponseBodyValidator = responseValidationFactory(
     [
@@ -295,24 +272,10 @@ export function createActivityRouter(implementation: ActivityImplementation): Ro
         },
       };
 
-      const response = await implementation.getUserActivityStats(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getUserActivityStatsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getUserActivityStats(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getUserActivityStatsResponseBodyValidator));
     } catch (error) {
       next(error);
     }

--- a/backend/generated/routes/admin.ts
+++ b/backend/generated/routes/admin.ts
@@ -2,24 +2,26 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ExpressRuntimeError, RequestInputType } from '@nahkies/typescript-express-runtime/errors';
+import { RequestInputType } from '@nahkies/typescript-express-runtime/errors';
 import {
   type ExpressRuntimeResponder,
   ExpressRuntimeResponse,
+  handleImplementationError,
+  handleResponse,
   type Params,
-  SkipResponse,
+  type SkipResponse,
   type StatusCode,
 } from '@nahkies/typescript-express-runtime/server';
 import { parseRequestInput, responseValidationFactory } from '@nahkies/typescript-express-runtime/zod-v4';
-import { type NextFunction, type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type RequestHandler, type Response, Router } from 'express';
 import { z } from 'zod/v4';
 import type {
   t_AdminReportListResponse,
   t_AffectedCountResponse,
   t_Announcement,
-  t_BatchUpdateAdminReportsRequestBodySchema,
-  t_BulkDeleteAdminReportsRequestBodySchema,
-  t_BulkUpdateAdminReportsRequestBodySchema,
+  t_BatchUpdateReportsRequest,
+  t_BulkDeleteReportsRequest,
+  t_BulkUpdateReportsRequest,
   t_CursorPagination,
   t_DeleteAdminReportParamSchema,
   t_Error400,
@@ -38,12 +40,11 @@ import type {
   t_RunAdminMediaAuditQuerySchema,
   t_RunAuditResponse,
   t_UpdateAdminMediaAuditParamSchema,
-  t_UpdateAdminMediaAuditRequestBodySchema,
+  t_UpdateAdminMediaAuditRequestBody,
   t_UpdateAdminReportParamSchema,
-  t_UpdateAdminReportRequestBodySchema,
-  t_UpdateAnnouncementRequestBodySchema,
+  t_UpdateReportRequest,
 } from '../models.ts';
-import type { AnnouncementOutput, BatchUpdateReportsRequestOutput, BulkDeleteReportsRequestOutput, BulkUpdateReportsRequestOutput, ListAdminMediaAuditRunsQueryOutput, ListAdminReportsQueryOutput, RunAdminMediaAuditQueryOutput, UpdateReportRequestOutput } from '../outputTypes.ts';
+import type { AnnouncementOutput, BatchUpdateReportsRequestOutput, BulkDeleteReportsRequestOutput, BulkUpdateReportsRequestOutput, ListAdminMediaAuditRunsQueryOutput, ListAdminReportsQueryOutput, RunAdminMediaAuditQueryOutput, UpdateAdminMediaAuditRequestBodyOutput, UpdateReportRequestOutput } from '../outputTypes.ts';
 import {
   PermissiveBoolean,
   s_AdminReportListResponse,
@@ -65,6 +66,7 @@ import {
   s_ReportSource,
   s_ReportTargetType,
   s_RunAuditResponse,
+  s_UpdateAdminMediaAuditRequestBody,
   s_UpdateReportRequest,
 } from '../schemas.ts';
 
@@ -197,7 +199,7 @@ export type UpdateAdminMediaAuditResponder = {
 } & ExpressRuntimeResponder;
 
 export type UpdateAdminMediaAudit = (
-  params: Params<t_UpdateAdminMediaAuditParamSchema, void, t_UpdateAdminMediaAuditRequestBodySchema, void>,
+  params: Params<t_UpdateAdminMediaAuditParamSchema, void, UpdateAdminMediaAuditRequestBodyOutput, void>,
   respond: UpdateAdminMediaAuditResponder,
   req: Request,
   res: Response,
@@ -308,8 +310,15 @@ export type AdminImplementation = {
   updateAnnouncement: UpdateAnnouncement;
 };
 
-export function createAdminRouter(implementation: AdminImplementation): Router {
+export function createAdminRouter(
+  implementation: AdminImplementation,
+  options: { middleware?: RequestHandler[] } = {},
+): Router {
   const router = Router();
+
+  if (options.middleware?.length) {
+    router.use(...options.middleware);
+  }
 
   const listAdminReportsQuerySchema = z.object({
     cursor: z.string().optional(),
@@ -366,30 +375,14 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.listAdminReports(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listAdminReportsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listAdminReports(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listAdminReportsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const batchUpdateAdminReportsRequestBodySchema = s_BatchUpdateReportsRequest;
 
   const batchUpdateAdminReportsResponseBodyValidator = responseValidationFactory(
     [
@@ -409,7 +402,7 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(batchUpdateAdminReportsRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_BatchUpdateReportsRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -437,30 +430,14 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.batchUpdateAdminReports(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(batchUpdateAdminReportsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .batchUpdateAdminReports(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, batchUpdateAdminReportsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const bulkUpdateAdminReportsRequestBodySchema = s_BulkUpdateReportsRequest;
 
   const bulkUpdateAdminReportsResponseBodyValidator = responseValidationFactory(
     [
@@ -480,7 +457,7 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(bulkUpdateAdminReportsRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_BulkUpdateReportsRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -508,30 +485,14 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.bulkUpdateAdminReports(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(bulkUpdateAdminReportsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .bulkUpdateAdminReports(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, bulkUpdateAdminReportsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const bulkDeleteAdminReportsRequestBodySchema = s_BulkDeleteReportsRequest;
 
   const bulkDeleteAdminReportsResponseBodyValidator = responseValidationFactory(
     [
@@ -551,7 +512,7 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(bulkDeleteAdminReportsRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_BulkDeleteReportsRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -579,32 +540,16 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.bulkDeleteAdminReports(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(bulkDeleteAdminReportsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .bulkDeleteAdminReports(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, bulkDeleteAdminReportsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
 
   const updateAdminReportParamSchema = z.object({ reportId: z.coerce.number() });
-
-  const updateAdminReportRequestBodySchema = s_UpdateReportRequest;
 
   const updateAdminReportResponseBodyValidator = responseValidationFactory(
     [
@@ -625,7 +570,7 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
       const input = {
         params: parseRequestInput(updateAdminReportParamSchema, req.params, RequestInputType.RouteParam),
         query: undefined,
-        body: parseRequestInput(updateAdminReportRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_UpdateReportRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -656,24 +601,10 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.updateAdminReport(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(updateAdminReportResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .updateAdminReport(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, updateAdminReportResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -727,24 +658,10 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.deleteAdminReport(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(deleteAdminReportResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .deleteAdminReport(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, deleteAdminReportResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -792,35 +709,16 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.listAdminMediaAudits(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listAdminMediaAuditsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listAdminMediaAudits(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listAdminMediaAuditsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
 
   const updateAdminMediaAuditParamSchema = z.object({ name: z.string() });
-
-  const updateAdminMediaAuditRequestBodySchema = z.object({
-    threshold: z.record(z.string(), z.unknown()).optional(),
-    enabled: PermissiveBoolean.optional(),
-  });
 
   const updateAdminMediaAuditResponseBodyValidator = responseValidationFactory(
     [
@@ -841,7 +739,7 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
       const input = {
         params: parseRequestInput(updateAdminMediaAuditParamSchema, req.params, RequestInputType.RouteParam),
         query: undefined,
-        body: parseRequestInput(updateAdminMediaAuditRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_UpdateAdminMediaAuditRequestBody, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -872,24 +770,10 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.updateAdminMediaAudit(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(updateAdminMediaAuditResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .updateAdminMediaAudit(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, updateAdminMediaAuditResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -945,24 +829,10 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.runAdminMediaAudit(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(runAdminMediaAuditResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .runAdminMediaAudit(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, runAdminMediaAuditResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1019,24 +889,10 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.listAdminMediaAuditRuns(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listAdminMediaAuditRunsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listAdminMediaAuditRuns(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listAdminMediaAuditRunsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1093,24 +949,10 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.getAdminMediaAuditRun(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getAdminMediaAuditRunResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getAdminMediaAuditRun(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getAdminMediaAuditRunResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1154,30 +996,14 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.getAnnouncement(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getAnnouncementResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getAnnouncement(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getAnnouncementResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const updateAnnouncementRequestBodySchema = s_Announcement;
 
   const updateAnnouncementResponseBodyValidator = responseValidationFactory(
     [
@@ -1197,7 +1023,7 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(updateAnnouncementRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_Announcement, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -1225,24 +1051,10 @@ export function createAdminRouter(implementation: AdminImplementation): Router {
         },
       };
 
-      const response = await implementation.updateAnnouncement(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(updateAnnouncementResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .updateAnnouncement(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, updateAnnouncementResponseBodyValidator));
     } catch (error) {
       next(error);
     }

--- a/backend/generated/routes/collections.ts
+++ b/backend/generated/routes/collections.ts
@@ -2,23 +2,26 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ExpressRuntimeError, RequestInputType } from '@nahkies/typescript-express-runtime/errors';
+import { RequestInputType } from '@nahkies/typescript-express-runtime/errors';
 import {
   type ExpressRuntimeResponder,
   ExpressRuntimeResponse,
+  handleImplementationError,
+  handleResponse,
   type Params,
-  SkipResponse,
+  type SkipResponse,
   type StatusCode,
 } from '@nahkies/typescript-express-runtime/server';
 import { parseRequestInput, responseValidationFactory } from '@nahkies/typescript-express-runtime/zod-v4';
-import { type NextFunction, type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type RequestHandler, type Response, Router } from 'express';
 import { z } from 'zod/v4';
 import type {
   t_AddSegmentToCollectionParamSchema,
-  t_AddSegmentToCollectionRequestBodySchema,
+  t_AddSegmentToCollectionRequest,
   t_Collection,
+  t_CollectionCreateRequest,
   t_CollectionListResponse,
-  t_CreateCollectionRequestBodySchema,
+  t_CollectionUpdateRequest,
   t_DeleteCollectionParamSchema,
   t_Error400,
   t_Error401,
@@ -31,13 +34,12 @@ import type {
   t_ListCollectionsQuerySchema,
   t_RemoveSegmentFromCollectionParamSchema,
   t_SearchCollectionSegmentsParamSchema,
-  t_SearchCollectionSegmentsRequestBodySchema,
+  t_SearchRequest,
   t_SearchResponse,
   t_SearchStatsResponse,
   t_UpdateCollectionParamSchema,
-  t_UpdateCollectionRequestBodySchema,
   t_UpdateCollectionSegmentParamSchema,
-  t_UpdateCollectionSegmentRequestBodySchema,
+  t_UpdateCollectionSegmentRequest,
 } from '../models.ts';
 import type { AddSegmentToCollectionRequestOutput, CollectionCreateRequestOutput, CollectionUpdateRequestOutput, ListCollectionsQueryOutput, SearchRequestOutput, UpdateCollectionSegmentRequestOutput } from '../outputTypes.ts';
 import {
@@ -250,8 +252,15 @@ export type CollectionsImplementation = {
   getCollectionStats: GetCollectionStats;
 };
 
-export function createCollectionsRouter(implementation: CollectionsImplementation): Router {
+export function createCollectionsRouter(
+  implementation: CollectionsImplementation,
+  options: { middleware?: RequestHandler[] } = {},
+): Router {
   const router = Router();
+
+  if (options.middleware?.length) {
+    router.use(...options.middleware);
+  }
 
   const listCollectionsQuerySchema = z.object({
     visibility: s_CollectionVisibility.optional(),
@@ -305,30 +314,14 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         },
       };
 
-      const response = await implementation.listCollections(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listCollectionsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listCollections(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listCollectionsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const createCollectionRequestBodySchema = s_CollectionCreateRequest;
 
   const createCollectionResponseBodyValidator = responseValidationFactory(
     [
@@ -348,7 +341,7 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(createCollectionRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_CollectionCreateRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -376,24 +369,10 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         },
       };
 
-      const response = await implementation.createCollection(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(createCollectionResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .createCollection(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, createCollectionResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -453,32 +432,16 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         },
       };
 
-      const response = await implementation.getCollection(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getCollectionResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getCollection(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getCollectionResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
 
   const updateCollectionParamSchema = z.object({ collectionPublicId: z.string() });
-
-  const updateCollectionRequestBodySchema = s_CollectionUpdateRequest;
 
   const updateCollectionResponseBodyValidator = responseValidationFactory(
     [
@@ -499,7 +462,7 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
       const input = {
         params: parseRequestInput(updateCollectionParamSchema, req.params, RequestInputType.RouteParam),
         query: undefined,
-        body: parseRequestInput(updateCollectionRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_CollectionUpdateRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -530,24 +493,10 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         },
       };
 
-      const response = await implementation.updateCollection(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(updateCollectionResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .updateCollection(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, updateCollectionResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -605,24 +554,10 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         },
       };
 
-      const response = await implementation.deleteCollection(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(deleteCollectionResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .deleteCollection(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, deleteCollectionResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -631,8 +566,6 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
   const addSegmentToCollectionParamSchema = z.object({
     collectionPublicId: z.string().regex(new RegExp('^[A-Za-z0-9_-]{12}$')),
   });
-
-  const addSegmentToCollectionRequestBodySchema = s_AddSegmentToCollectionRequest;
 
   const addSegmentToCollectionResponseBodyValidator = responseValidationFactory(
     [
@@ -655,7 +588,7 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         const input = {
           params: parseRequestInput(addSegmentToCollectionParamSchema, req.params, RequestInputType.RouteParam),
           query: undefined,
-          body: parseRequestInput(addSegmentToCollectionRequestBodySchema, req.body, RequestInputType.RequestBody),
+          body: parseRequestInput(s_AddSegmentToCollectionRequest, req.body, RequestInputType.RequestBody),
           headers: undefined,
         };
 
@@ -686,24 +619,10 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
           },
         };
 
-        const response = await implementation.addSegmentToCollection(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(addSegmentToCollectionResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .addSegmentToCollection(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, addSegmentToCollectionResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -713,8 +632,6 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
   const searchCollectionSegmentsParamSchema = z.object({
     collectionPublicId: z.string().regex(new RegExp('^[A-Za-z0-9_-]{12}$')),
   });
-
-  const searchCollectionSegmentsRequestBodySchema = s_SearchRequest;
 
   const searchCollectionSegmentsResponseBodyValidator = responseValidationFactory(
     [
@@ -735,7 +652,7 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
       const input = {
         params: parseRequestInput(searchCollectionSegmentsParamSchema, req.params, RequestInputType.RouteParam),
         query: undefined,
-        body: parseRequestInput(searchCollectionSegmentsRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_SearchRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -766,24 +683,10 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         },
       };
 
-      const response = await implementation.searchCollectionSegments(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(searchCollectionSegmentsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .searchCollectionSegments(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, searchCollectionSegmentsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -793,8 +696,6 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
     collectionPublicId: z.string().regex(new RegExp('^[A-Za-z0-9_-]{12}$')),
     segmentPublicId: z.string().regex(new RegExp('^[A-Za-z0-9_-]{12}$')),
   });
-
-  const updateCollectionSegmentRequestBodySchema = s_UpdateCollectionSegmentRequest;
 
   const updateCollectionSegmentResponseBodyValidator = responseValidationFactory(
     [
@@ -817,7 +718,7 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         const input = {
           params: parseRequestInput(updateCollectionSegmentParamSchema, req.params, RequestInputType.RouteParam),
           query: undefined,
-          body: parseRequestInput(updateCollectionSegmentRequestBodySchema, req.body, RequestInputType.RequestBody),
+          body: parseRequestInput(s_UpdateCollectionSegmentRequest, req.body, RequestInputType.RequestBody),
           headers: undefined,
         };
 
@@ -848,24 +749,10 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
           },
         };
 
-        const response = await implementation.updateCollectionSegment(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(updateCollectionSegmentResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .updateCollectionSegment(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, updateCollectionSegmentResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -929,26 +816,10 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
           },
         };
 
-        const response = await implementation
+        await implementation
           .removeSegmentFromCollection(input, responder, req, res, next)
-          .catch((err) => {
-            throw ExpressRuntimeError.HandlerError(err);
-          });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(removeSegmentFromCollectionResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+          .catch(handleImplementationError)
+          .then(handleResponse(res, removeSegmentFromCollectionResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -1007,24 +878,10 @@ export function createCollectionsRouter(implementation: CollectionsImplementatio
         },
       };
 
-      const response = await implementation.getCollectionStats(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getCollectionStatsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getCollectionStats(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getCollectionStatsResponseBodyValidator));
     } catch (error) {
       next(error);
     }

--- a/backend/generated/routes/media.ts
+++ b/backend/generated/routes/media.ts
@@ -2,29 +2,29 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ExpressRuntimeError, RequestInputType } from '@nahkies/typescript-express-runtime/errors';
+import { RequestInputType } from '@nahkies/typescript-express-runtime/errors';
 import {
   type ExpressRuntimeResponder,
   ExpressRuntimeResponse,
+  handleImplementationError,
+  handleResponse,
   type Params,
-  SkipResponse,
+  type SkipResponse,
   type StatusCode,
 } from '@nahkies/typescript-express-runtime/server';
 import { parseRequestInput, responseValidationFactory } from '@nahkies/typescript-express-runtime/zod-v4';
-import { type NextFunction, type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type RequestHandler, type Response, Router } from 'express';
 import { z } from 'zod/v4';
 import type {
   t_CreateEpisodeParamSchema,
-  t_CreateEpisodeRequestBodySchema,
-  t_CreateMediaRequestBodySchema,
   t_CreateSegmentParamSchema,
-  t_CreateSegmentRequestBodySchema,
   t_CreateSegmentsBatchParamSchema,
-  t_CreateSegmentsBatchRequestBodySchema,
   t_DeleteEpisodeParamSchema,
   t_DeleteMediaParamSchema,
   t_Episode,
+  t_EpisodeCreateRequest,
   t_EpisodeListResponse,
+  t_EpisodeUpdateRequest,
   t_Error400,
   t_Error401,
   t_Error403,
@@ -44,18 +44,20 @@ import type {
   t_ListSegmentsParamSchema,
   t_ListSegmentsQuerySchema,
   t_Media,
+  t_MediaCreateRequest,
   t_MediaListResponse,
+  t_MediaUpdateRequest,
   t_Segment,
+  t_SegmentBatchCreateRequest,
   t_SegmentContextResponse,
+  t_SegmentCreateRequest,
   t_SegmentInternal,
   t_SegmentListResponse,
   t_SegmentRevision,
+  t_SegmentUpdateRequest,
   t_UpdateEpisodeParamSchema,
-  t_UpdateEpisodeRequestBodySchema,
   t_UpdateMediaParamSchema,
-  t_UpdateMediaRequestBodySchema,
   t_UpdateSegmentParamSchema,
-  t_UpdateSegmentRequestBodySchema,
 } from '../models.ts';
 import type { EpisodeCreateRequestOutput, EpisodeUpdateRequestOutput, GetSegmentContextQueryOutput, ListEpisodesQueryOutput, ListMediaQueryOutput, ListSegmentsQueryOutput, MediaCreateRequestOutput, MediaUpdateRequestOutput, SegmentBatchCreateRequestOutput, SegmentCreateRequestOutput, SegmentUpdateRequestOutput } from '../outputTypes.ts';
 import {
@@ -418,8 +420,15 @@ export type MediaImplementation = {
   createSegmentsBatch: CreateSegmentsBatch;
 };
 
-export function createMediaRouter(implementation: MediaImplementation): Router {
+export function createMediaRouter(
+  implementation: MediaImplementation,
+  options: { middleware?: RequestHandler[] } = {},
+): Router {
   const router = Router();
+
+  if (options.middleware?.length) {
+    router.use(...options.middleware);
+  }
 
   const listMediaQuerySchema = z.object({
     take: z.coerce.number().min(1).max(40).optional().default(20),
@@ -474,30 +483,14 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.listMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const createMediaRequestBodySchema = s_MediaCreateRequest;
 
   const createMediaResponseBodyValidator = responseValidationFactory(
     [
@@ -518,7 +511,7 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(createMediaRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_MediaCreateRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -549,24 +542,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.createMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(createMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .createMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, createMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -624,32 +603,16 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.getSegment(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getSegmentResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getSegment(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getSegmentResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
 
   const updateSegmentParamSchema = z.object({ segmentPublicId: z.string().regex(new RegExp('^[A-Za-z0-9_-]{12}$')) });
-
-  const updateSegmentRequestBodySchema = s_SegmentUpdateRequest;
 
   const updateSegmentResponseBodyValidator = responseValidationFactory(
     [
@@ -670,7 +633,7 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
       const input = {
         params: parseRequestInput(updateSegmentParamSchema, req.params, RequestInputType.RouteParam),
         query: undefined,
-        body: parseRequestInput(updateSegmentRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_SegmentUpdateRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -701,24 +664,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.updateSegment(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(updateSegmentResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .updateSegment(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, updateSegmentResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -789,24 +738,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.getSegmentContext(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getSegmentContextResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getSegmentContext(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getSegmentContextResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -868,24 +803,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
           },
         };
 
-        const response = await implementation.listSegmentRevisions(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(listSegmentRevisionsResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .listSegmentRevisions(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, listSegmentRevisionsResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -944,32 +865,16 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.getMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
 
   const updateMediaParamSchema = z.object({ mediaPublicId: z.string() });
-
-  const updateMediaRequestBodySchema = s_MediaUpdateRequest;
 
   const updateMediaResponseBodyValidator = responseValidationFactory(
     [
@@ -990,7 +895,7 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
       const input = {
         params: parseRequestInput(updateMediaParamSchema, req.params, RequestInputType.RouteParam),
         query: undefined,
-        body: parseRequestInput(updateMediaRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_MediaUpdateRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -1021,24 +926,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.updateMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(updateMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .updateMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, updateMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1096,24 +987,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.deleteMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(deleteMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .deleteMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, deleteMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1176,32 +1053,16 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.listEpisodes(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listEpisodesResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listEpisodes(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listEpisodesResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
 
   const createEpisodeParamSchema = z.object({ mediaPublicId: z.string() });
-
-  const createEpisodeRequestBodySchema = s_EpisodeCreateRequest;
 
   const createEpisodeResponseBodyValidator = responseValidationFactory(
     [
@@ -1223,7 +1084,7 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
       const input = {
         params: parseRequestInput(createEpisodeParamSchema, req.params, RequestInputType.RouteParam),
         query: undefined,
-        body: parseRequestInput(createEpisodeRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_EpisodeCreateRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -1257,24 +1118,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         },
       };
 
-      const response = await implementation.createEpisode(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(createEpisodeResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .createEpisode(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, createEpisodeResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1337,24 +1184,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
           },
         };
 
-        const response = await implementation.getEpisode(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(getEpisodeResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .getEpisode(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, getEpisodeResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -1362,8 +1195,6 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
   );
 
   const updateEpisodeParamSchema = z.object({ mediaPublicId: z.string(), episodeNumber: z.coerce.number().min(0) });
-
-  const updateEpisodeRequestBodySchema = s_EpisodeUpdateRequest;
 
   const updateEpisodeResponseBodyValidator = responseValidationFactory(
     [
@@ -1386,7 +1217,7 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         const input = {
           params: parseRequestInput(updateEpisodeParamSchema, req.params, RequestInputType.RouteParam),
           query: undefined,
-          body: parseRequestInput(updateEpisodeRequestBodySchema, req.body, RequestInputType.RequestBody),
+          body: parseRequestInput(s_EpisodeUpdateRequest, req.body, RequestInputType.RequestBody),
           headers: undefined,
         };
 
@@ -1417,24 +1248,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
           },
         };
 
-        const response = await implementation.updateEpisode(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(updateEpisodeResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .updateEpisode(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, updateEpisodeResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -1495,24 +1312,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
           },
         };
 
-        const response = await implementation.deleteEpisode(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(deleteEpisodeResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .deleteEpisode(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, deleteEpisodeResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -1578,24 +1381,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
           },
         };
 
-        const response = await implementation.listSegments(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(listSegmentsResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .listSegments(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, listSegmentsResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -1603,8 +1392,6 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
   );
 
   const createSegmentParamSchema = z.object({ mediaPublicId: z.string(), episodeNumber: z.coerce.number() });
-
-  const createSegmentRequestBodySchema = s_SegmentCreateRequest;
 
   const createSegmentResponseBodyValidator = responseValidationFactory(
     [
@@ -1628,7 +1415,7 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         const input = {
           params: parseRequestInput(createSegmentParamSchema, req.params, RequestInputType.RouteParam),
           query: undefined,
-          body: parseRequestInput(createSegmentRequestBodySchema, req.body, RequestInputType.RequestBody),
+          body: parseRequestInput(s_SegmentCreateRequest, req.body, RequestInputType.RequestBody),
           headers: undefined,
         };
 
@@ -1662,24 +1449,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
           },
         };
 
-        const response = await implementation.createSegment(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(createSegmentResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .createSegment(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, createSegmentResponseBodyValidator));
       } catch (error) {
         next(error);
       }
@@ -1690,8 +1463,6 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
     mediaPublicId: z.string(),
     episodeNumber: z.coerce.number().min(0),
   });
-
-  const createSegmentsBatchRequestBodySchema = s_SegmentBatchCreateRequest;
 
   const createSegmentsBatchResponseBodyValidator = responseValidationFactory(
     [
@@ -1714,7 +1485,7 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
         const input = {
           params: parseRequestInput(createSegmentsBatchParamSchema, req.params, RequestInputType.RouteParam),
           query: undefined,
-          body: parseRequestInput(createSegmentsBatchRequestBodySchema, req.body, RequestInputType.RequestBody),
+          body: parseRequestInput(s_SegmentBatchCreateRequest, req.body, RequestInputType.RequestBody),
           headers: undefined,
         };
 
@@ -1748,24 +1519,10 @@ export function createMediaRouter(implementation: MediaImplementation): Router {
           },
         };
 
-        const response = await implementation.createSegmentsBatch(input, responder, req, res, next).catch((err) => {
-          throw ExpressRuntimeError.HandlerError(err);
-        });
-
-        // escape hatch to allow responses to be sent by the implementation handler
-        if (response === SkipResponse) {
-          return;
-        }
-
-        const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-        res.status(status);
-
-        if (body !== undefined) {
-          res.json(createSegmentsBatchResponseBodyValidator(status, body));
-        } else {
-          res.end();
-        }
+        await implementation
+          .createSegmentsBatch(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, createSegmentsBatchResponseBodyValidator));
       } catch (error) {
         next(error);
       }

--- a/backend/generated/routes/search.ts
+++ b/backend/generated/routes/search.ts
@@ -2,30 +2,32 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ExpressRuntimeError, RequestInputType } from '@nahkies/typescript-express-runtime/errors';
+import { RequestInputType } from '@nahkies/typescript-express-runtime/errors';
 import {
   type ExpressRuntimeResponder,
   ExpressRuntimeResponse,
+  handleImplementationError,
+  handleResponse,
   type Params,
-  SkipResponse,
+  type SkipResponse,
   type StatusCode,
 } from '@nahkies/typescript-express-runtime/server';
 import { parseRequestInput, responseValidationFactory } from '@nahkies/typescript-express-runtime/zod-v4';
-import { type NextFunction, type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type RequestHandler, type Response, Router } from 'express';
 import type {
   t_Error400,
   t_Error401,
   t_Error403,
   t_Error429,
   t_Error500,
-  t_GetSearchStatsRequestBodySchema,
   t_MediaAutocompleteResponse,
-  t_SearchMediaRequestBodySchema,
+  t_SearchMediaRequest,
+  t_SearchMultipleRequest,
   t_SearchMultipleResponse,
-  t_SearchRequestBodySchema,
+  t_SearchRequest,
   t_SearchResponse,
+  t_SearchStatsRequest,
   t_SearchStatsResponse,
-  t_SearchWordsRequestBodySchema,
 } from '../models.ts';
 import type { SearchMediaRequestOutput, SearchMultipleRequestOutput, SearchRequestOutput, SearchStatsRequestOutput } from '../outputTypes.ts';
 import {
@@ -119,10 +121,15 @@ export type SearchImplementation = {
   searchMedia: SearchMedia;
 };
 
-export function createSearchRouter(implementation: SearchImplementation): Router {
+export function createSearchRouter(
+  implementation: SearchImplementation,
+  options: { middleware?: RequestHandler[] } = {},
+): Router {
   const router = Router();
 
-  const searchRequestBodySchema = s_SearchRequest;
+  if (options.middleware?.length) {
+    router.use(...options.middleware);
+  }
 
   const searchResponseBodyValidator = responseValidationFactory(
     [
@@ -142,7 +149,7 @@ export function createSearchRouter(implementation: SearchImplementation): Router
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(searchRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_SearchRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -170,30 +177,14 @@ export function createSearchRouter(implementation: SearchImplementation): Router
         },
       };
 
-      const response = await implementation.search(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(searchResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .search(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, searchResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const getSearchStatsRequestBodySchema = s_SearchStatsRequest;
 
   const getSearchStatsResponseBodyValidator = responseValidationFactory(
     [
@@ -213,7 +204,7 @@ export function createSearchRouter(implementation: SearchImplementation): Router
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(getSearchStatsRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_SearchStatsRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -241,30 +232,14 @@ export function createSearchRouter(implementation: SearchImplementation): Router
         },
       };
 
-      const response = await implementation.getSearchStats(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getSearchStatsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getSearchStats(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getSearchStatsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const searchWordsRequestBodySchema = s_SearchMultipleRequest;
 
   const searchWordsResponseBodyValidator = responseValidationFactory(
     [
@@ -284,7 +259,7 @@ export function createSearchRouter(implementation: SearchImplementation): Router
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(searchWordsRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_SearchMultipleRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -312,30 +287,14 @@ export function createSearchRouter(implementation: SearchImplementation): Router
         },
       };
 
-      const response = await implementation.searchWords(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(searchWordsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .searchWords(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, searchWordsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const searchMediaRequestBodySchema = s_SearchMediaRequest;
 
   const searchMediaResponseBodyValidator = responseValidationFactory(
     [
@@ -355,7 +314,7 @@ export function createSearchRouter(implementation: SearchImplementation): Router
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(searchMediaRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_SearchMediaRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -383,24 +342,10 @@ export function createSearchRouter(implementation: SearchImplementation): Router
         },
       };
 
-      const response = await implementation.searchMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(searchMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .searchMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, searchMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }

--- a/backend/generated/routes/stats.ts
+++ b/backend/generated/routes/stats.ts
@@ -2,19 +2,22 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ExpressRuntimeError, RequestInputType } from '@nahkies/typescript-express-runtime/errors';
+import { RequestInputType } from '@nahkies/typescript-express-runtime/errors';
 import {
   type ExpressRuntimeResponder,
   ExpressRuntimeResponse,
+  handleImplementationError,
+  handleResponse,
   type Params,
-  SkipResponse,
+  type SkipResponse,
   type StatusCode,
 } from '@nahkies/typescript-express-runtime/server';
 import { parseRequestInput, responseValidationFactory } from '@nahkies/typescript-express-runtime/zod-v4';
-import { type NextFunction, type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type RequestHandler, type Response, Router } from 'express';
 import { z } from 'zod/v4';
 import type {
   t_CoveredWordsResponse,
+  t_CoveredWordsUpdateRequest,
   t_CoveredWordsUpdateResponse,
   t_Error400,
   t_Error401,
@@ -23,7 +26,6 @@ import type {
   t_Error500,
   t_GetCoveredWordsQuerySchema,
   t_StatsOverview,
-  t_TriggerCoveredWordsUpdateRequestBodySchema,
 } from '../models.ts';
 import type { CoveredWordsUpdateRequestOutput, GetCoveredWordsQueryOutput } from '../outputTypes.ts';
 import {
@@ -94,8 +96,15 @@ export type StatsImplementation = {
   triggerCoveredWordsUpdate: TriggerCoveredWordsUpdate;
 };
 
-export function createStatsRouter(implementation: StatsImplementation): Router {
+export function createStatsRouter(
+  implementation: StatsImplementation,
+  options: { middleware?: RequestHandler[] } = {},
+): Router {
   const router = Router();
+
+  if (options.middleware?.length) {
+    router.use(...options.middleware);
+  }
 
   const getStatsOverviewResponseBodyValidator = responseValidationFactory(
     [
@@ -139,24 +148,10 @@ export function createStatsRouter(implementation: StatsImplementation): Router {
         },
       };
 
-      const response = await implementation.getStatsOverview(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getStatsOverviewResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getStatsOverview(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getStatsOverviewResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -216,30 +211,14 @@ export function createStatsRouter(implementation: StatsImplementation): Router {
         },
       };
 
-      const response = await implementation.getCoveredWords(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getCoveredWordsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getCoveredWords(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getCoveredWordsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const triggerCoveredWordsUpdateRequestBodySchema = s_CoveredWordsUpdateRequest;
 
   const triggerCoveredWordsUpdateResponseBodyValidator = responseValidationFactory(
     [
@@ -259,7 +238,7 @@ export function createStatsRouter(implementation: StatsImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(triggerCoveredWordsUpdateRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_CoveredWordsUpdateRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -287,24 +266,10 @@ export function createStatsRouter(implementation: StatsImplementation): Router {
         },
       };
 
-      const response = await implementation.triggerCoveredWordsUpdate(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(triggerCoveredWordsUpdateResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .triggerCoveredWordsUpdate(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, triggerCoveredWordsUpdateResponseBodyValidator));
     } catch (error) {
       next(error);
     }

--- a/backend/generated/routes/user.ts
+++ b/backend/generated/routes/user.ts
@@ -2,21 +2,23 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ExpressRuntimeError, RequestInputType } from '@nahkies/typescript-express-runtime/errors';
+import { RequestInputType } from '@nahkies/typescript-express-runtime/errors';
 import {
   type ExpressRuntimeResponder,
   ExpressRuntimeResponse,
+  handleImplementationError,
+  handleResponse,
   type Params,
-  SkipResponse,
+  type SkipResponse,
   type StatusCode,
 } from '@nahkies/typescript-express-runtime/server';
 import { parseRequestInput, responseValidationFactory } from '@nahkies/typescript-express-runtime/zod-v4';
-import { type NextFunction, type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type RequestHandler, type Response, Router } from 'express';
 import { z } from 'zod/v4';
 import type {
-  t_AddExcludedMediaRequestBodySchema,
+  t_AddExcludedMediaRequestBody,
   t_AffectedCountResponse,
-  t_CreateUserReportRequestBodySchema,
+  t_CreateReportRequest,
   t_DeleteUserActivityByDateParamSchema,
   t_DeleteUserActivityByIdParamSchema,
   t_DeleteUserActivityQuerySchema,
@@ -30,17 +32,17 @@ import type {
   t_MediaSummary,
   t_RemoveExcludedMediaParamSchema,
   t_Report,
-  t_TrackUserActivityRequestBodySchema,
   t_UnenrollUserLabParamSchema,
-  t_UpdateUserPreferencesRequestBodySchema,
+  t_UserActivityRequest,
   t_UserExportResponse,
   t_UserLabFeature,
   t_UserMe,
   t_UserPreferences,
 } from '../models.ts';
-import type { CreateReportRequestOutput, DeleteUserActivityQueryOutput, UserActivityRequestOutput, UserPreferencesOutput } from '../outputTypes.ts';
+import type { AddExcludedMediaRequestBodyOutput, CreateReportRequestOutput, DeleteUserActivityQueryOutput, UserActivityRequestOutput, UserPreferencesOutput } from '../outputTypes.ts';
 import {
   s_ActivityType,
+  s_AddExcludedMediaRequestBody,
   s_AffectedCountResponse,
   s_CreateReportRequest,
   s_Error400,
@@ -103,7 +105,7 @@ export type AddExcludedMediaResponder = {
 } & ExpressRuntimeResponder;
 
 export type AddExcludedMedia = (
-  params: Params<void, void, t_AddExcludedMediaRequestBodySchema, void>,
+  params: Params<void, void, AddExcludedMediaRequestBodyOutput, void>,
   respond: AddExcludedMediaResponder,
   req: Request,
   res: Response,
@@ -327,8 +329,15 @@ export type UserImplementation = {
   unenrollUserLab: UnenrollUserLab;
 };
 
-export function createUserRouter(implementation: UserImplementation): Router {
+export function createUserRouter(
+  implementation: UserImplementation,
+  options: { middleware?: RequestHandler[] } = {},
+): Router {
   const router = Router();
+
+  if (options.middleware?.length) {
+    router.use(...options.middleware);
+  }
 
   const getMeResponseBodyValidator = responseValidationFactory(
     [
@@ -372,24 +381,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.getMe(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getMeResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getMe(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getMeResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -439,31 +434,13 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.listExcludedMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listExcludedMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listExcludedMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listExcludedMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }
-  });
-
-  const addExcludedMediaRequestBodySchema = z.object({
-    mediaPublicId: z.string().regex(new RegExp('^[A-Za-z0-9_-]{12}$')),
   });
 
   const addExcludedMediaResponseBodyValidator = responseValidationFactory(
@@ -485,7 +462,7 @@ export function createUserRouter(implementation: UserImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(addExcludedMediaRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_AddExcludedMediaRequestBody, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -516,24 +493,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.addExcludedMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(addExcludedMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .addExcludedMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, addExcludedMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -589,30 +552,14 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.removeExcludedMedia(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(removeExcludedMediaResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .removeExcludedMedia(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, removeExcludedMediaResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const createUserReportRequestBodySchema = s_CreateReportRequest;
 
   const createUserReportResponseBodyValidator = responseValidationFactory(
     [
@@ -632,7 +579,7 @@ export function createUserRouter(implementation: UserImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(createUserReportRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_CreateReportRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -660,24 +607,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.createUserReport(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(createUserReportResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .createUserReport(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, createUserReportResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -725,30 +658,14 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.getUserPreferences(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(getUserPreferencesResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .getUserPreferences(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, getUserPreferencesResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const updateUserPreferencesRequestBodySchema = s_UserPreferences;
 
   const updateUserPreferencesResponseBodyValidator = responseValidationFactory(
     [
@@ -768,7 +685,7 @@ export function createUserRouter(implementation: UserImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(updateUserPreferencesRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_UserPreferences, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -796,30 +713,14 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.updateUserPreferences(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(updateUserPreferencesResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .updateUserPreferences(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, updateUserPreferencesResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
-
-  const trackUserActivityRequestBodySchema = s_UserActivityRequest;
 
   const trackUserActivityResponseBodyValidator = responseValidationFactory(
     [
@@ -839,7 +740,7 @@ export function createUserRouter(implementation: UserImplementation): Router {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(trackUserActivityRequestBodySchema, req.body, RequestInputType.RequestBody),
+        body: parseRequestInput(s_UserActivityRequest, req.body, RequestInputType.RequestBody),
         headers: undefined,
       };
 
@@ -867,24 +768,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.trackUserActivity(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(trackUserActivityResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .trackUserActivity(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, trackUserActivityResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -934,30 +821,16 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.deleteUserActivity(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(deleteUserActivityResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .deleteUserActivity(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, deleteUserActivityResponseBodyValidator));
     } catch (error) {
       next(error);
     }
   });
 
-  const deleteUserActivityByDateParamSchema = z.object({ date: z.string() });
+  const deleteUserActivityByDateParamSchema = z.object({ date: z.iso.date() });
 
   const deleteUserActivityByDateResponseBodyValidator = responseValidationFactory(
     [
@@ -1001,24 +874,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.deleteUserActivityByDate(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(deleteUserActivityByDateResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .deleteUserActivityByDate(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, deleteUserActivityByDateResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1072,24 +931,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.deleteUserActivityById(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(deleteUserActivityByIdResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .deleteUserActivityById(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, deleteUserActivityByIdResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1137,24 +982,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.exportUserData(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(exportUserDataResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .exportUserData(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, exportUserDataResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1202,24 +1033,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.listUserLabs(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(listUserLabsResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .listUserLabs(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, listUserLabsResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1273,24 +1090,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.enrollUserLab(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(enrollUserLabResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .enrollUserLab(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, enrollUserLabResponseBodyValidator));
     } catch (error) {
       next(error);
     }
@@ -1344,24 +1147,10 @@ export function createUserRouter(implementation: UserImplementation): Router {
         },
       };
 
-      const response = await implementation.unenrollUserLab(input, responder, req, res, next).catch((err) => {
-        throw ExpressRuntimeError.HandlerError(err);
-      });
-
-      // escape hatch to allow responses to be sent by the implementation handler
-      if (response === SkipResponse) {
-        return;
-      }
-
-      const { status, body } = response instanceof ExpressRuntimeResponse ? response.unpack() : response;
-
-      res.status(status);
-
-      if (body !== undefined) {
-        res.json(unenrollUserLabResponseBodyValidator(status, body));
-      } else {
-        res.end();
-      }
+      await implementation
+        .unenrollUserLab(input, responder, req, res, next)
+        .catch(handleImplementationError)
+        .then(handleResponse(res, unenrollUserLabResponseBodyValidator));
     } catch (error) {
       next(error);
     }

--- a/backend/generated/schemas.ts
+++ b/backend/generated/schemas.ts
@@ -118,7 +118,7 @@ export const s_Error403 = z.object({
 });
 
 export const s_Error404 = z.object({
-  code: z.enum(['NOT_FOUND']),
+  code: z.literal('NOT_FOUND'),
   title: z.string().min(1),
   detail: z.string().min(1),
   type: z.string().min(1).optional(),
@@ -148,7 +148,7 @@ export const s_Error429 = z.object({
 });
 
 export const s_Error500 = z.object({
-  code: z.enum(['INTERNAL_SERVER_EXCEPTION']),
+  code: z.literal('INTERNAL_SERVER_EXCEPTION'),
   title: z.string().min(1),
   detail: z.string().min(1),
   type: z.string().min(1).optional(),
@@ -172,7 +172,7 @@ export const s_HeatmapDayCounts = z.object({
   SHARE: z.coerce.number().min(0).optional(),
 });
 
-export const s_IncludeExpansion = z.enum(['media']);
+export const s_IncludeExpansion = z.literal('media');
 
 export const s_MediaAudit = z.object({
   id: z.coerce.number(),
@@ -257,22 +257,22 @@ export const s_ReportSource = z.enum(['USER', 'AUTO']);
 export const s_ReportStatus = z.enum(['OPEN', 'PROCESSING', 'FIXED', 'DISMISSED']);
 
 export const s_ReportTargetEpisode = z.object({
-  type: z.enum(['EPISODE']),
+  type: z.literal('EPISODE'),
   mediaPublicId: z.string(),
   episodeNumber: z.coerce.number(),
 });
 
-export const s_ReportTargetMedia = z.object({ type: z.enum(['MEDIA']), mediaPublicId: z.string() });
+export const s_ReportTargetMedia = z.object({ type: z.literal('MEDIA'), mediaPublicId: z.string() });
 
 export const s_ReportTargetSegment = z.object({
-  type: z.enum(['SEGMENT']),
+  type: z.literal('SEGMENT'),
   mediaPublicId: z.string(),
   episodeNumber: z.coerce.number().optional(),
   segmentPublicId: z.string().nullable(),
 });
 
 export const s_ReportTargetSegmentInput = z.object({
-  type: z.enum(['SEGMENT']),
+  type: z.literal('SEGMENT'),
   mediaPublicId: z.string(),
   episodeNumber: z.coerce.number().optional(),
   segmentPublicId: z.string(),
@@ -518,8 +518,8 @@ export const s_Media = z.object({
   genres: z.array(z.string().min(1)),
   coverUrl: z.string().min(1),
   bannerUrl: z.string().min(1),
-  startDate: z.string().min(1),
-  endDate: z.string().min(1).nullable(),
+  startDate: z.iso.date().min(1),
+  endDate: z.iso.date().min(1).nullable(),
   category: s_Category,
   segmentCount: z.coerce.number().min(0),
   episodeCount: z.coerce.number().min(0),
@@ -537,8 +537,8 @@ export const s_MediaCreateRequest = z.object({
   airingStatus: z.enum(['FINISHED', 'RELEASING', 'NOT_YET_RELEASED', 'CANCELLED']),
   genres: z.array(z.string()),
   storage: z.enum(['LOCAL', 'R2']).default('R2'),
-  startDate: z.string(),
-  endDate: z.string().optional(),
+  startDate: z.iso.date(),
+  endDate: z.iso.date().optional(),
   category: s_Category,
   version: z.string(),
   hashSalt: z.string(),
@@ -567,8 +567,8 @@ export const s_MediaUpdateRequest = z.object({
   airingStatus: z.enum(['FINISHED', 'RELEASING', 'NOT_YET_RELEASED', 'CANCELLED']).optional(),
   genres: z.array(z.string()).optional(),
   storage: z.enum(['LOCAL', 'R2']).optional(),
-  startDate: z.string().optional(),
-  endDate: z.string().nullable().optional(),
+  startDate: z.iso.date().optional(),
+  endDate: z.iso.date().nullable().optional(),
   category: s_Category.optional(),
   version: z.string().optional(),
   hashSalt: z.string().optional(),
@@ -579,7 +579,11 @@ export const s_MediaUpdateRequest = z.object({
   segmentCount: z.coerce.number().min(0).optional(),
 });
 
-export const s_ReportTarget = z.union([s_ReportTargetMedia, s_ReportTargetEpisode, s_ReportTargetSegment]);
+export const s_ReportTarget = z.discriminatedUnion('type', [
+  s_ReportTargetMedia,
+  s_ReportTargetEpisode,
+  s_ReportTargetSegment,
+]);
 
 export const s_SearchFilters = z.object({
   media: z
@@ -708,7 +712,7 @@ export const s_UserActivity = z.object({
   createdAt: z.iso.datetime({ offset: true }),
 });
 
-export const s_UserReportTarget = z.union([s_ReportTargetMedia, s_ReportTargetSegmentInput]);
+export const s_UserReportTarget = z.discriminatedUnion('type', [s_ReportTargetMedia, s_ReportTargetSegmentInput]);
 
 export const s_WordMatch = z.object({
   word: z.string().min(1),
@@ -829,19 +833,17 @@ export const s_SegmentContextResponse = z.object({
   includes: z.object({ media: z.record(z.string(), s_Media).optional() }).optional(),
 });
 
-export const s_SegmentInternal = s_Segment.merge(
-  z.object({
-    storage: z.enum(['LOCAL', 'R2']).nullable().optional(),
-    hashedId: z.string().nullable().optional(),
-    storageBasePath: z.string().nullable().optional(),
-    ratingAnalysis: z.record(z.string(), z.unknown()).nullable().optional(),
-    posAnalysis: z.record(z.string(), z.unknown()).nullable().optional(),
-  }),
-);
+export const s_SegmentInternal = s_Segment.extend({
+  storage: z.enum(['LOCAL', 'R2']).nullable().optional(),
+  hashedId: z.string().nullable().optional(),
+  storageBasePath: z.string().nullable().optional(),
+  ratingAnalysis: z.record(z.string(), z.unknown()).nullable().optional(),
+  posAnalysis: z.record(z.string(), z.unknown()).nullable().optional(),
+});
 
 export const s_SegmentListResponse = z.object({ segments: z.array(s_Segment), pagination: s_CursorPagination });
 
-export const s_UserExportCollection = s_Collection.merge(z.object({ segmentIds: z.array(z.coerce.number()) }));
+export const s_UserExportCollection = s_Collection.extend({ segmentIds: z.array(z.coerce.number()) });
 
 export const s_AdminReportListResponse = z.object({
   groups: z.array(s_AdminReportGroup),
@@ -859,4 +861,13 @@ export const s_UserExportResponse = z.object({
   activity: z.array(s_UserActivity),
   collections: z.array(s_UserExportCollection),
   reports: z.array(s_Report),
+});
+
+export const s_AddExcludedMediaRequestBody = z.object({
+  mediaPublicId: z.string().regex(new RegExp('^[A-Za-z0-9_-]{12}$')),
+});
+
+export const s_UpdateAdminMediaAuditRequestBody = z.object({
+  threshold: z.record(z.string(), z.unknown()).optional(),
+  enabled: PermissiveBoolean.optional(),
 });

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/client-sesv2": "^3.1044.0",
     "@better-auth/api-key": "^1.6.25",
     "@elastic/elasticsearch": "^8.19.1",
-    "@nahkies/typescript-express-runtime": "0.22.0",
+    "@nahkies/typescript-express-runtime": "0.26.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.10.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
@@ -90,7 +90,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
-    "@nahkies/openapi-code-generator": "0.22.0",
+    "@nahkies/openapi-code-generator": "0.26.0",
     "@redocly/cli": "^2.30.2",
     "@types/bun": "^1.3.13",
     "@types/express": "^5.0.6",


### PR DESCRIPTION
## Summary
- update `@nahkies/openapi-code-generator` and `@nahkies/typescript-express-runtime` together from 0.22.0 to 0.26.0
- regenerate the Express/Zod server surface
- adapt `generateOutputTypes.ts` to Nahkies 0.23+ inline `parseRequestInput(s_X, ...)` output while retaining support for the legacy alias format
- preserve parsed `z.output` request types so defaults remain materialized for controller implementations

## Notable generated changes
- singleton enums now use literals
- report target unions use discriminated unions
- Zod object composition uses `extend` instead of deprecated `merge`
- OpenAPI `format: date` fields now use ISO date validation
- route operations and exported schemas are preserved; obsolete request-body aliases are removed

## Validation
- frozen install
- Redocly lint and bundle
- deterministic generation (identical SHA-256 across two runs)
- backend lint and typecheck
- 713 backend tests, 0 failures
- full backend Docker image build
- `git diff --check`

The source OpenAPI specification and generated bundles are unchanged.