### PR TITLE
chore(deps): upgrade express-rate-limit to v8

### DIFF
--- a/backend/app/middleware/rateLimit.ts
+++ b/backend/app/middleware/rateLimit.ts
@@ -83,6 +83,7 @@ function buildHandler(scope: 'global' | 'auth', detail: string): RequestHandler 
 export const globalRateLimit: RequestHandler = rateLimit({
   windowMs: WINDOW_MS,
   limit: DEFAULT_MAX,
+  ipv6Subnet: 56,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
   skip: shouldSkip,
@@ -92,6 +93,7 @@ export const globalRateLimit: RequestHandler = rateLimit({
 export const authRateLimit: RequestHandler = rateLimit({
   windowMs: WINDOW_MS,
   limit: AUTH_MAX,
+  ipv6Subnet: 56,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
   skip: shouldSkip,

--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -28,7 +28,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
-        "express-rate-limit": "^7.5.1",
+        "express-rate-limit": "^8.6.0",
         "helmet": "^8.3.0",
         "nanoid": "^5.1.16",
         "nodemailer": "^9.0.3",
@@ -885,7 +885,7 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+    "express-rate-limit": ["express-rate-limit@8.6.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA=="],
 
     "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
 
@@ -997,7 +997,7 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "ip-address": ["ip-address@10.3.1", "", {}, "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g=="],
 
     "ip-regex": ["ip-regex@5.0.0", "", {}, "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="],
 
@@ -1896,6 +1896,8 @@
     "pg/pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "socks/ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -74,7 +74,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "express-rate-limit": "^7.5.1",
+    "express-rate-limit": "^8.6.0",
     "helmet": "^8.3.0",
     "nanoid": "^5.1.16",
     "nodemailer": "^9.0.3",

--- a/backend/tests/middleware/rateLimit.test.ts
+++ b/backend/tests/middleware/rateLimit.test.ts
@@ -40,7 +40,42 @@ describe('rateLimit', () => {
     expect(last?.status).toBe(429);
     expect(last?.body).toMatchObject({ code: 'RATE_LIMIT_EXCEEDED', status: 429 });
     expect(last?.headers['retry-after']).toBeDefined();
-  });
+  }, 15_000);
+
+  it('groups IPv6 addresses in the same /56 into one rate-limit bucket', async () => {
+    const app = buildApp();
+    const max = config.RATE_LIMIT_MAX_REQUESTS_PER_IP;
+
+    for (let i = 0; i < max; i++) {
+      const response = await request(app).get('/ping').set('X-Forwarded-For', '2001:db8:abcd:1200::1');
+      expect(response.status).toBe(200);
+    }
+
+    const sameSubnetResponse = await request(app).get('/ping').set('X-Forwarded-For', '2001:db8:abcd:12ff::2');
+    const differentSubnetResponse = await request(app).get('/ping').set('X-Forwarded-For', '2001:db8:abcd:1300::1');
+
+    expect(sameSubnetResponse.status).toBe(429);
+    expect(differentSubnetResponse.status).toBe(200);
+  }, 15_000);
+
+  it('groups IPv6 addresses in the same /56 for auth routes without affecting adjacent subnets', async () => {
+    const app = buildApp();
+
+    for (let i = 0; i < config.RATE_LIMIT_AUTH_MAX_REQUESTS_PER_IP; i++) {
+      const response = await request(app).get('/v1/auth/get-session').set('X-Forwarded-For', '2001:db8:abcd:3400::1');
+      expect(response.status).toBe(200);
+    }
+
+    const sameSubnetResponse = await request(app)
+      .get('/v1/auth/get-session')
+      .set('X-Forwarded-For', '2001:db8:abcd:34ff::2');
+    const differentSubnetResponse = await request(app)
+      .get('/v1/auth/get-session')
+      .set('X-Forwarded-For', '2001:db8:abcd:3500::1');
+
+    expect(sameSubnetResponse.status).toBe(429);
+    expect(differentSubnetResponse.status).toBe(200);
+  }, 15_000);
 
   it('exempts proxied traffic carrying the valid internal-proxy secret', async () => {
     const app = buildApp();
@@ -57,7 +92,7 @@ describe('rateLimit', () => {
       statuses.push(r.status);
     }
     expect(statuses.every((s) => s === 200)).toBe(true);
-  });
+  }, 15_000);
 
   it('does NOT exempt traffic with a wrong/forged internal-proxy secret', async () => {
     const app = buildApp();
@@ -70,7 +105,7 @@ describe('rateLimit', () => {
       statuses.push(r.status);
     }
     expect(statuses).toContain(429);
-  });
+  }, 15_000);
 
   it('auth route is separately (more tightly) rate-limited', async () => {
     const app = buildApp();
@@ -82,7 +117,7 @@ describe('rateLimit', () => {
     expect(statuses).toContain(429);
     // The auth limit is tighter than the global one, so it must trip first.
     expect(statuses.indexOf(429)).toBeLessThan(config.RATE_LIMIT_MAX_REQUESTS_PER_IP);
-  });
+  }, 15_000);
 });
 
 describe('rateLimit skip for SERVICE keys', () => {
@@ -116,7 +151,7 @@ describe('rateLimit skip for SERVICE keys', () => {
       statuses.push(r.status);
     }
     expect(statuses.every((s) => s === 200)).toBe(true);
-  });
+  }, 15_000);
 
   it('never rate-limits SERVICE key requests (auth)', async () => {
     const app = buildServiceKeyApp();
@@ -126,5 +161,5 @@ describe('rateLimit skip for SERVICE keys', () => {
       statuses.push(r.status);
     }
     expect(statuses.every((s) => s === 200)).toBe(true);
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary

- upgrade backend `express-rate-limit` from `^7.5.1` to `^8.6.0`
- explicitly group IPv6 clients by `/56` for both global and auth limiters
- add regression coverage for shared and adjacent IPv6 subnets
- give request-intensive rate-limit tests explicit time budgets to avoid load-dependent 5-second timeouts

## Breaking-change analysis

`express-rate-limit` v8 changed IPv6 handling to use subnet-aware keys. Nadeshiko now configures `ipv6Subnet: 56` explicitly rather than relying on a library default.

The tests verify that:

- distinct addresses inside one `/56` share the global bucket
- an address in the adjacent `/56` remains independent
- the same boundary applies to auth routes
- SERVICE-key and internal-proxy exemptions remain intact
- the existing standard 429 response envelope and headers remain intact

## TDD evidence

Before upgrading, the new IPv6 regression test failed on v7 as expected:

```text
Expected: 429
Received: 200
```

After upgrading and configuring `/56` bucketing:

```text
9 pass
0 fail
378 expect() calls
```

## Validation

- `bun install --frozen-lockfile`: pass
- backend check/lint/typecheck/OpenAPI: pass
- focused rate-limit tests: 9 pass, 0 fail
- complete backend suite with ephemeral PostgreSQL 16 and Elasticsearch: 718 pass, 0 fail, 1,950 assertions
- backend production Dockerfile build: pass
- image: `sha256:bcbcacba3655c3527a61a9379fae0c277f0cc30810f35916f2cb16149aac3b33`
- ephemeral test containers and listeners cleaned up: verified
- independent pre-commit review: approved, no security concerns or logic errors

## Scope

Only backend `express-rate-limit`, its lockfile entries, limiter configuration, and targeted tests are changed. No other pending major dependency is included.
