### PR TITLE
chore(deps): upgrade nanoid to v6

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -30,7 +30,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.6.0",
         "helmet": "^8.3.0",
-        "nanoid": "^5.1.16",
+        "nanoid": "^6.0.0",
         "nodemailer": "^9.0.3",
         "pg": "^8.22.0",
         "pg-boss": "^12.26.3",
@@ -1133,7 +1133,7 @@
 
     "nanoclone": ["nanoclone@0.2.1", "", {}, "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="],
 
-    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
 
     "nanostores": ["nanostores@1.1.1", "", {}, "sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -47,7 +47,7 @@
   "author": "",
   "license": "AGPL-3.0",
   "engines": {
-    "node": ">=22.0.0",
+    "node": "^22 || ^24 || >=26",
     "bun": ">=1.0.0"
   },
   "dependencies": {
@@ -76,7 +76,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.6.0",
     "helmet": "^8.3.0",
-    "nanoid": "^5.1.16",
+    "nanoid": "^6.0.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.22.0",
     "pg-boss": "^12.26.3",


### PR DESCRIPTION
## Summary

- upgrade backend `nanoid` from `^5.1.16` to `^6.0.0`
- align the backend Node engine declaration with Nano ID 6's supported even-numbered releases
- leave Bruno's independent transitive Nano ID 3 resolutions unchanged

## Breaking-change analysis

Nano ID 6 preserves the ESM named export and `nanoid(size)` API used by Nadeshiko. Its declared breaking change is runtime support: Node 18 and 20 were removed, and the package supports `^22 || ^24 || >=26`.

Nadeshiko's backend production image uses Node 22. CI and staging E2E also use Node 22. The backend engine range is narrowed from `>=22.0.0` to `^22 || ^24 || >=26` so it no longer claims compatibility with unsupported Node 23 or 25.

All seven production consumers continue to call `nanoid(12)`.

## Validation

- `bun install --frozen-lockfile`: pass
- backend lint/OpenAPI/typecheck: pass
- generated API output: deterministic and clean
- full backend suite with ephemeral PostgreSQL 16 and repository-built Elasticsearch/Sudachi image: 718 pass, 0 fail, 1,950 assertions
- production backend Dockerfile build: pass
- image: `sha256:7b8701f5a1cf5f01e439f38c1cc1a74fb3e2d90e90049bc48136f7663107149c`
- inside-image runtime smoke on Node v22.23.1: 10,000 URL-safe 12-character IDs generated, 10,000 unique
- ephemeral services and listeners cleaned up: verified
- independent review: approved, no security concerns or logic errors

## Scope

Only `backend/package.json` and the direct Nano ID resolution in `backend/bun.lock` change. No source code, generated output, SDK, or unrelated dependency is included.
