### PR TITLE
chore(frontend): remove unused Chrome types

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -43,7 +43,6 @@
         "@nuxtjs/critters": "^0.9.2",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "@playwright/test": "^1.62.0",
-        "@types/chrome": "^0.1.43",
         "@vue/test-utils": "^2.4.11",
         "@vueuse/core": "^14.3.0",
         "@vueuse/nuxt": "^14.3.0",
@@ -782,19 +781,11 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
-    "@types/chrome": ["@types/chrome@0.1.43", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA=="],
-
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
-
-    "@types/filesystem": ["@types/filesystem@0.0.36", "", { "dependencies": { "@types/filewriter": "*" } }, "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA=="],
-
-    "@types/filewriter": ["@types/filewriter@0.0.33", "", {}, "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g=="],
-
-    "@types/har-format": ["@types/har-format@1.2.16", "", {}, "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,6 @@
     "@nuxtjs/critters": "^0.9.2",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@playwright/test": "^1.62.0",
-    "@types/chrome": "^0.1.43",
     "@vue/test-utils": "^2.4.11",
     "@vueuse/core": "^14.3.0",
     "@vueuse/nuxt": "^14.3.0",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,4 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json",
-  "compilerOptions": {
-    "types": ["chrome"]
-  }
+  "extends": "./.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
## Summary

- remove the unused `@types/chrome` frontend development dependency instead of carrying it across the pending `0.1` to `0.2` major
- remove the explicit `types: ["chrome"]` global injection from the frontend TypeScript configuration
- remove the four lockfile entries that were exclusive to the Chrome type package

## Rationale

A repository-wide frontend search found no use of:

- `chrome.*` globals
- Chrome extension APIs
- Chrome-specific imported types
- `/// <reference types="chrome" />`

Keeping the package would globally expose extension APIs to an ordinary Nuxt web application without any consumer. Removing it narrows the ambient type surface and avoids an unnecessary major upgrade.

Nuxt's generated TypeScript configuration remains authoritative after the explicit override is removed.

## Removed dependency subtree

- `@types/chrome`
- `@types/filesystem`
- `@types/filewriter`
- `@types/har-format`

`bun pm why @types/chrome` confirms that the package is absent from the resulting graph.

## Validation

- `bun install --frozen-lockfile`
- Nuxt type generation (`postinstall` / `nuxt prepare`)
- `bun run lint`
- `bun run typecheck`
- `bun run test`: 4 files, 62 tests passed
- `bun run build`
- exact `frontend/Dockerfile` build
- `git diff --check`
- independent fail-closed review: approved with no security concerns, logic errors, or suggestions

Local Docker image:

```text
sha256:f31174d288582f3286658fffcae742d6d64c0a4fbbef143593a564815b0f25de
```
