### PR TITLE
chore(elasticsearch): publish 8.19 bridge image

### DIFF
--- a/.github/workflows/elasticsearch-image.yml
+++ b/.github/workflows/elasticsearch-image.yml
@@ -1,0 +1,43 @@
+name: "[Infra] Elasticsearch Image"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - backend/docker/Dockerfile.elasticsearch
+      - .github/workflows/elasticsearch-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  ELASTICSEARCH_IMAGE_TAG: 8.19.15-sudachi-3.6.0-dict-20260116
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Elasticsearch image
+        uses: docker/build-push-action@v7
+        with:
+          context: backend
+          file: backend/docker/Dockerfile.elasticsearch
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/brigadasos/nadeshiko-elasticsearch:${{ env.ELASTICSEARCH_IMAGE_TAG }}
+            ghcr.io/brigadasos/nadeshiko-elasticsearch:${{ env.ELASTICSEARCH_IMAGE_TAG }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend/docker/Dockerfile.elasticsearch
+++ b/backend/docker/Dockerfile.elasticsearch
@@ -1,9 +1,17 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:8.17.10
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.19.15@sha256:785913a22bd053dde1fb93d7098a1a58e0fc894cffc195752772c0d2682900ec
 RUN bin/elasticsearch-plugin install analysis-icu
-RUN bin/elasticsearch-plugin install \
-  https://github.com/WorksApplications/elasticsearch-sudachi/releases/download/v3.4.0/elasticsearch-8.17.10-analysis-sudachi-3.4.0.zip
+# Sudachi 3.6 declares read access to config/sudachi; --batch accepts that
+# reviewed entitlement so image builds remain non-interactive.
+ADD --chown=elasticsearch:root --chmod=0644 \
+  --checksum=sha256:ba5f83df76ef26e47fc005df2c7614fee0f7318958edf261623b09e9d39621c3 \
+  https://github.com/WorksApplications/elasticsearch-sudachi/releases/download/v3.6.0/elasticsearch-8.19.15-analysis-sudachi-3.6.0.zip \
+  /tmp/elasticsearch-analysis-sudachi.zip
+RUN bin/elasticsearch-plugin install --batch file:///tmp/elasticsearch-analysis-sudachi.zip && \
+  rm /tmp/elasticsearch-analysis-sudachi.zip
 USER root
-ADD https://github.com/WorksApplications/SudachiDict/releases/download/v20260116/sudachi-dictionary-20260116-full.zip /tmp/sudachi-dict-full.zip
+ADD --checksum=sha256:2a1eda5a0240a42f45daf8003d97df5565c5d252bb2d58e71807bbbd082f7eea \
+  https://github.com/WorksApplications/SudachiDict/releases/download/v20260116/sudachi-dictionary-20260116-full.zip \
+  /tmp/sudachi-dict-full.zip
 RUN apt-get update && apt-get install -y --no-install-recommends unzip && \
   mkdir -p config/sudachi && \
   unzip /tmp/sudachi-dict-full.zip -d /tmp/sudachi-dict && \


### PR DESCRIPTION
## Summary

Publishes a reproducible Elasticsearch **8.19.15 bridge image** for the first phase of the Elasticsearch 9 migration.

This PR is deliberately **publication-only**:

- upgrades the custom image from Elasticsearch 8.17.10 to 8.19.15;
- installs `analysis-icu` and `analysis-sudachi` 3.6.0;
- installs Sudachi full dictionary `20260116`;
- pins the official linux/amd64 Elasticsearch base by digest;
- pins the Sudachi plugin and dictionary downloads by SHA-256;
- adds a GHCR publication workflow with component-specific and commit-specific tags;
- does **not** modify Kamal deployment configuration or restart the production accessory.

## Why 8.19.15

Elasticsearch requires the cluster to pass through the latest compatible 8.19 line before moving to 9.x. Sudachi 3.6.0 publishes an exact Elasticsearch artifact for 8.19.15. Newer 8.19 patches currently lack a matching published Sudachi artifact, so 8.19.15 is the highest exact server/plugin pairing demonstrated here.

## Verification

- `git diff --check`: pass
- `actionlint`: pass
- static added-line security scan: 0 findings
- independent fail-closed review: pass, 0 security concerns, 0 logic errors
- native `linux/amd64` Docker build on an x86_64 host: pass
- runtime version: Elasticsearch 8.19.15
- runtime plugins: `analysis-icu`, `analysis-sudachi`
- backend frozen install/lint/typecheck/generated-drift gate: pass
- backend suite against the bridge image: **718 passed, 0 failed**
- backend Docker build: pass

Validated native image artifact:

```text
IMAGE=sha256:f3b233e21f1b7679d2de441e2f5f4fa7df74982dcd6c1d9b255be1c45fecb824
ARCH=amd64
SIZE=1905331297
```

The local validation tag/image was removed from the production host after verification. No running container or persistent volume was changed.

## Production sequencing

After merge:

1. wait for this workflow to publish successfully;
2. inspect and record the GHCR manifest digest;
3. take and restore-drill a complete production Elasticsearch snapshot;
4. create a separate digest-pinned deployment PR;
5. upgrade the accessory during an explicit maintenance window;
6. verify health, counts, aliases, security state, writes and Japanese analyzer behavior;
7. soak on 8.19 before preparing the separate server-9 and client-9 phases.

Production currently remains on Elasticsearch 8.17.10. Merging this PR alone does not update it.
