### PR TITLE
feat(search): complete Elasticsearch 9 migration

### DIFF
--- a/.github/workflows/elasticsearch-image.yml
+++ b/.github/workflows/elasticsearch-image.yml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  ELASTICSEARCH_IMAGE_TAG: 8.19.15-sudachi-3.6.0-dict-20260116
+  ELASTICSEARCH_IMAGE_TAG: 9.4.1-sudachi-3.6.0-dict-20260116
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ permissions:
   packages: write
   id-token: write
 
+concurrency:
+  group: nadeshiko-production-release
+  cancel-in-progress: false
+
 jobs:
   release-backend:
     runs-on: ubuntu-latest
@@ -32,11 +36,11 @@ jobs:
       - name: Install backend dependencies
         run: cd backend && bun install --frozen-lockfile
 
-      - name: Get latest release tag
+      - name: Read triggering release tag
         id: get-tag
         run: |
           set -euo pipefail
-          RELEASE_TAG=$(git describe --tags --abbrev=0)
+          RELEASE_TAG=${GITHUB_REF_NAME:?tag ref is required}
           echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           VERSION="${RELEASE_TAG#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -51,6 +55,8 @@ jobs:
             echo "Invalid semver tag: ${RELEASE_TAG}"
             exit 1
           fi
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
           bun run release:check-version "${VERSION}"
 
       - name: Generate OpenAPI specs
@@ -119,14 +125,46 @@ jobs:
       - name: Install Kamal
         run: gem install kamal -v '~> 2.0'
 
-      - name: Deploy backend to prod
+      - name: Migrate Elasticsearch and deploy backend to prod
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           ssh-keyscan -H nadeshiko >> ~/.ssh/known_hosts 2>/dev/null || true
+
+          component='ghcr.io/brigadasos/nadeshiko-elasticsearch:9.4.1-sudachi-3.6.0-dict-20260116'
+          source_sha=$(git log --first-parent -1 --format=%H -- backend/docker/Dockerfile.elasticsearch)
+          commit_tag="${component}-${source_sha}"
+          docker pull "$component"
+          docker pull "$commit_tag"
+          component_digest=$(docker image inspect "$component" --format '{{index .RepoDigests 0}}')
+          elasticsearch_image=$(docker image inspect "$commit_tag" --format '{{index .RepoDigests 0}}')
+          test -n "$elasticsearch_image"
+          test "$component_digest" = "$elasticsearch_image"
+
+          backend_tag="ghcr.io/brigadasos/nadeshiko-backend-prod:${GITHUB_SHA}"
+          docker pull "$backend_tag"
+          backend_image=$(docker image inspect "$backend_tag" --format '{{index .RepoDigests 0}}')
+          test -n "$backend_image"
+
+          admin_user=$(aws ssm get-parameter --name "/nadeshiko/prod/ELASTICSEARCH_ADMIN_USER" --with-decryption --query 'Parameter.Value' --output text)
+          admin_password=$(aws ssm get-parameter --name "/nadeshiko/prod/ELASTICSEARCH_ADMIN_PASSWORD" --with-decryption --query 'Parameter.Value' --output text)
+          test -n "$admin_user"
+          test -n "$admin_password"
+          if [[ "$admin_user" == *$'\n'* || "$admin_user" == *$'\r'* || "$admin_password" == *$'\n'* || "$admin_password" == *$'\r'* ]]; then
+            echo 'Elasticsearch administrative values must not contain CR/LF characters.' >&2
+            exit 1
+          fi
+          echo "::add-mask::${admin_user}"
+          echo "::add-mask::${admin_password}"
+          admin_env=$(mktemp)
+          trap 'rm -f "$admin_env"' EXIT
+          umask 077
+          printf 'ELASTICSEARCH_ADMIN_USER=%s\nELASTICSEARCH_ADMIN_PASSWORD=%s\n' \
+            "$admin_user" "$admin_password" >"$admin_env"
+
           cd backend
-          kamal deploy -d prod --skip-push
+          bash scripts/migrate-elasticsearch-production.sh "$elasticsearch_image" "$backend_image" "$GITHUB_SHA" "$admin_env"
 
   release-frontend:
     needs: release-backend
@@ -269,8 +307,8 @@ jobs:
           set -euo pipefail
           gh api repos/BrigadaSOS/nadeshiko-sdk-ts/dispatches \
             -f event_type='backend_release' \
-            -f client_payload[release_channel]="stable" \
-            -f client_payload[backend_sha]="${GITHUB_SHA}"
+            -f 'client_payload[release_channel]=stable' \
+            -f "client_payload[backend_sha]=${GITHUB_SHA}"
 
   dispatch-sdk-python:
     needs: release-backend
@@ -283,5 +321,5 @@ jobs:
           set -euo pipefail
           gh api repos/BrigadaSOS/nadeshiko-sdk-python/dispatches \
             -f event_type='backend_release' \
-            -f client_payload[release_channel]="stable" \
-            -f client_payload[backend_sha]="${GITHUB_SHA}"
+            -f 'client_payload[release_channel]=stable' \
+            -f "client_payload[backend_sha]=${GITHUB_SHA}"

--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -16,11 +16,20 @@ on:
         required: false
         default: 'false'
         type: boolean
+      bootstrap_elasticsearch_canary:
+        description: 'Boot and populate the isolated Elasticsearch staging canary'
+        required: false
+        default: 'false'
+        type: boolean
 
 permissions:
   contents: read
   packages: write
   id-token: write
+
+concurrency:
+  group: nadeshiko-staging-release
+  cancel-in-progress: false
 
 jobs:
   changes:
@@ -29,6 +38,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
       openapi: ${{ steps.filter.outputs.openapi }}
+      elasticsearch: ${{ steps.filter.outputs.elasticsearch }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -37,14 +47,25 @@ jobs:
           filters: |
             backend:
               - 'backend/**'
+            elasticsearch:
+              - 'backend/docker/Dockerfile.elasticsearch'
+              - 'backend/package.json'
+              - 'backend/bun.lock'
+              - 'backend/config/elasticsearch.ts'
+              - 'backend/config/elasticsearch-client.ts'
+              - 'backend/config/deploy.staging.yml'
+              - 'backend/scripts/bootstrap-elasticsearch-staging-canary.sh'
             frontend:
               - 'frontend/**'
             openapi:
               - 'backend/docs/openapi/**'
 
   deploy-backend:
-    needs: changes
-    if: needs.changes.outputs.backend == 'true' || inputs.force_backend == 'true'
+    needs: [changes, bootstrap-elasticsearch-canary]
+    if: >-
+      always() &&
+      (needs.changes.outputs.backend == 'true' || inputs.force_backend == true || inputs.bootstrap_elasticsearch_canary == true) &&
+      (needs.changes.outputs.elasticsearch != 'true' || needs.bootstrap-elasticsearch-canary.result == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -96,6 +117,19 @@ jobs:
           chmod 700 ~/.ssh
           chmod 600 ~/.ssh/config
 
+      - name: Verify Elasticsearch 9 prerequisite
+        run: |
+          set -euo pipefail
+          ssh-keyscan -H nadeshiko >> ~/.ssh/known_hosts 2>/dev/null || true
+          health=$(ssh nadeshiko "sudo -n docker exec nadeshiko-backend-stg-elasticsearch bash -c 'curl --fail --silent --user \"elastic:\$ELASTICSEARCH_ADMIN_PASSWORD\" http://localhost:9200/_cluster/health'")
+          grep -q '"timed_out":false' <<<"$health"
+          grep -Eq '"status":"(yellow|green)"' <<<"$health"
+          version=$(ssh nadeshiko 'sudo -n docker exec nadeshiko-backend-stg-elasticsearch /usr/share/elasticsearch/bin/elasticsearch --version')
+          grep -q 'Version: 9.4.1' <<<"$version"
+          plugins=$(ssh nadeshiko 'sudo -n docker exec nadeshiko-backend-stg-elasticsearch /usr/share/elasticsearch/bin/elasticsearch-plugin list')
+          grep -qx analysis-icu <<<"$plugins"
+          grep -qx analysis-sudachi <<<"$plugins"
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -113,9 +147,132 @@ jobs:
           cd backend
           kamal deploy -d staging --skip-push
 
+      - name: Populate and verify Elasticsearch canary
+        if: inputs.bootstrap_elasticsearch_canary == true
+        run: |
+          set -euo pipefail
+          admin_user=$(aws ssm get-parameter --name "/nadeshiko/staging/ELASTICSEARCH_ADMIN_USER" --with-decryption --query 'Parameter.Value' --output text)
+          admin_password=$(aws ssm get-parameter --name "/nadeshiko/staging/ELASTICSEARCH_ADMIN_PASSWORD" --with-decryption --query 'Parameter.Value' --output text)
+          echo "::add-mask::${admin_user}"
+          echo "::add-mask::${admin_password}"
+
+          stage=$(mktemp -d)
+          trap 'rm -rf "$stage"' EXIT
+          umask 077
+          printf 'ELASTICSEARCH_ADMIN_USER=%s\nELASTICSEARCH_ADMIN_PASSWORD=%s\n' \
+            "$admin_user" "$admin_password" >"$stage/admin.env"
+          cp backend/scripts/bootstrap-elasticsearch-staging-canary.sh "$stage/run.sh"
+
+          tar -C "$stage" -cf - . | ssh nadeshiko '
+            set -euo pipefail
+            stage=$(mktemp -d)
+            trap '\''sudo -n rm -rf "$stage"'\'' EXIT
+            tar -C "$stage" -xf -
+            bash "$stage/run.sh" "$stage/admin.env"
+          '
+
+  bootstrap-elasticsearch-canary:
+    if: inputs.bootstrap_elasticsearch_canary == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-nadeshiko-staging
+          aws-region: eu-north-1
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: nadeshiko
+
+      - name: Configure SSH over Tailscale
+        run: |
+          mkdir -p ~/.ssh
+          cat >> ~/.ssh/config <<'EOF'
+          Host nadeshiko
+            ProxyCommand tailscale nc %h %p
+          EOF
+          chmod 700 ~/.ssh
+          chmod 600 ~/.ssh/config
+          ssh-keyscan -H nadeshiko >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: Install Kamal
+        run: gem install kamal -v '~> 2.0'
+
+      - name: Boot isolated Elasticsearch canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          component='ghcr.io/brigadasos/nadeshiko-elasticsearch:9.4.1-sudachi-3.6.0-dict-20260116'
+          source_sha=$(git log --first-parent -1 --format=%H -- backend/docker/Dockerfile.elasticsearch)
+          commit_tag="${component}-${source_sha}"
+          docker pull "$component"
+          docker pull "$commit_tag"
+          component_digest=$(docker image inspect "$component" --format '{{index .RepoDigests 0}}')
+          expected=$(docker image inspect "$commit_tag" --format '{{index .RepoDigests 0}}')
+          test -n "$expected"
+          test "$component_digest" = "$expected"
+
+          if ssh nadeshiko 'sudo -n docker inspect nadeshiko-backend-stg-elasticsearch >/dev/null 2>&1'; then
+            actual=$(ssh nadeshiko 'sudo -n docker inspect nadeshiko-backend-stg-elasticsearch --format "{{.Config.Image}}"')
+            if [ "$actual" != "$expected" ]; then
+              ssh nadeshiko 'sudo -n docker rm --force nadeshiko-backend-stg-elasticsearch >/dev/null'
+              cd backend
+              ELASTICSEARCH_IMAGE="$expected" kamal accessory boot elasticsearch -d staging
+            elif [ "$(ssh nadeshiko 'sudo -n docker inspect nadeshiko-backend-stg-elasticsearch --format "{{.State.Running}}"')" != true ]; then
+              ssh nadeshiko 'sudo -n docker start nadeshiko-backend-stg-elasticsearch >/dev/null'
+            fi
+          else
+            cd backend
+            ELASTICSEARCH_IMAGE="$expected" kamal accessory boot elasticsearch -d staging
+          fi
+
+          actual=$(ssh nadeshiko 'sudo -n docker inspect nadeshiko-backend-stg-elasticsearch --format "{{.Config.Image}}"')
+          test "$actual" = "$expected"
+
+          for attempt in $(seq 1 90); do
+            health=$(ssh nadeshiko "sudo -n docker exec nadeshiko-backend-stg-elasticsearch bash -c 'curl --fail --silent --user \"elastic:\$ELASTICSEARCH_ADMIN_PASSWORD\" http://localhost:9200/_cluster/health'" 2>/dev/null || true)
+            if grep -q '"timed_out":false' <<<"$health" && grep -Eq '"status":"(yellow|green)"' <<<"$health"; then
+              break
+            fi
+            if [ "$attempt" -eq 90 ]; then
+              ssh nadeshiko 'sudo -n docker logs --tail 200 nadeshiko-backend-stg-elasticsearch'
+              exit 1
+            fi
+            sleep 2
+          done
+          version=$(ssh nadeshiko 'sudo -n docker exec nadeshiko-backend-stg-elasticsearch /usr/share/elasticsearch/bin/elasticsearch --version')
+          grep -q 'Version: 9.4.1' <<<"$version"
+          plugins=$(ssh nadeshiko 'sudo -n docker exec nadeshiko-backend-stg-elasticsearch /usr/share/elasticsearch/bin/elasticsearch-plugin list')
+          grep -qx analysis-icu <<<"$plugins"
+          grep -qx analysis-sudachi <<<"$plugins"
+
+
   deploy-frontend:
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || inputs.force_frontend == 'true'
+    if: needs.changes.outputs.frontend == 'true' || inputs.force_frontend == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -263,8 +420,8 @@ jobs:
           set -euo pipefail
           gh api repos/BrigadaSOS/nadeshiko-sdk-ts/dispatches \
             -f event_type='backend_release' \
-            -f client_payload[release_channel]="internal" \
-            -f client_payload[backend_sha]="${GITHUB_SHA}"
+            -f 'client_payload[release_channel]=internal' \
+            -f "client_payload[backend_sha]=${GITHUB_SHA}"
 
   dispatch-sdk-python:
     needs: changes
@@ -294,5 +451,5 @@ jobs:
           set -euo pipefail
           gh api repos/BrigadaSOS/nadeshiko-sdk-python/dispatches \
             -f event_type='backend_release' \
-            -f client_payload[release_channel]="internal" \
-            -f client_payload[backend_sha]="${GITHUB_SHA}"
+            -f 'client_payload[release_channel]=internal' \
+            -f "client_payload[backend_sha]=${GITHUB_SHA}"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,6 +13,7 @@ COPY package.json tsconfig.json main.ts instrumentation.ts ./
 COPY app ./app
 COPY config ./config
 COPY db ./db
+COPY bin ./bin
 COPY lib ./lib
 COPY generated ./generated
 ENTRYPOINT []

--- a/backend/app/models/mediaAudit/checks/dbEsSyncIssues.ts
+++ b/backend/app/models/mediaAudit/checks/dbEsSyncIssues.ts
@@ -28,11 +28,9 @@ export const dbEsSyncIssues: MediaAuditCheck = {
     const esResponse = await ctx.esClient.search({
       index: '_all',
       size: 0,
-      body: {
-        aggs: {
-          media: {
-            terms: { field: 'mediaId', size: 10000 },
-          },
+      aggs: {
+        media: {
+          terms: { field: 'mediaId', size: 10000 },
         },
       },
     });

--- a/backend/app/models/segmentDocument/SegmentIndexer.ts
+++ b/backend/app/models/segmentDocument/SegmentIndexer.ts
@@ -235,6 +235,15 @@ export class SegmentIndexer {
         'Reindex completed',
       );
 
+      if (stats.failedIndexes > 0 || errors.length > 0) {
+        return {
+          success: false,
+          message: `Reindex completed with ${stats.failedIndexes} failed document(s)`,
+          stats,
+          errors,
+        };
+      }
+
       return { success: true, message: 'Reindex operation completed', stats, errors };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/backend/bin/db.ts
+++ b/backend/bin/db.ts
@@ -107,6 +107,7 @@ async function setupElasticsearchUserAndRole(options: { recreateIfExists?: boole
   logger.info('Setting up Elasticsearch user and role...');
   try {
     const { setupElasticsearchUser, initializeElasticsearchIndexWithClient } = await import('@config/elasticsearch');
+    const { ELASTICSEARCH_CLIENT_DEFAULTS } = await import('@config/elasticsearch-client');
     const { Client } = await import('@elastic/elasticsearch');
 
     // Create admin client
@@ -126,6 +127,7 @@ async function setupElasticsearchUserAndRole(options: { recreateIfExists?: boole
         password: adminPassword,
       },
       Connection: HttpConnection,
+      ...ELASTICSEARCH_CLIENT_DEFAULTS,
     });
 
     // Create user and role first
@@ -175,6 +177,7 @@ Commands:
   setup     Reset target database tables + ES role/user/index + migrate + seed (destructive)
   reset     Alias for setup (destructive)
   prepare   Non-destructive deploy task: migrate if needed + infrastructure checks
+  prepare-es  Create the Elasticsearch app role/user and initialize its alias only
   drop      Drop all tables (destructive!)
   status    Show if there are pending migrations
 
@@ -223,6 +226,9 @@ async function main(): Promise<void> {
         }
         await AppDataSource.initialize();
         await prepare();
+        break;
+      case 'prepare-es':
+        await setupElasticsearchUserAndRole();
         break;
       case 'drop':
         ensureDestructiveAllowed('db:drop', commandArgs);

--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@aws-sdk/client-sesv2": "^3.1095.0",
         "@better-auth/api-key": "^1.6.25",
-        "@elastic/elasticsearch": "^8.19.2",
+        "@elastic/elasticsearch": "^9.4.2",
         "@nahkies/typescript-express-runtime": "0.26.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/core": "^2.10.0",
@@ -293,9 +293,9 @@
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
-    "@elastic/elasticsearch": ["@elastic/elasticsearch@8.19.2", "", { "dependencies": { "@elastic/transport": "^8.9.6", "apache-arrow": "18.x - 21.x", "tslib": "^2.4.0" } }, "sha512-LMJCju/+AZkDlJArd/MYABWTDrHi4U7j3qGTKi1hYC7+67SaiYmYFItiueACQVrj2j3ECPMcguZ+7WrZeB+Z5g=="],
+    "@elastic/elasticsearch": ["@elastic/elasticsearch@9.4.2", "", { "dependencies": { "@elastic/transport": "^9.3.5", "tslib": "^2.4.0" }, "peerDependencies": { "apache-arrow": "18.x - 21.x" }, "optionalPeers": ["apache-arrow"] }, "sha512-H9myMlLUeotkZhZ4ppinoMGDFxmW3lY8/s+4TIk1vFHyCvWU1Ej4T7azX5buCzemyFApgN0ywnEuvOtpel2VZg=="],
 
-    "@elastic/transport": ["@elastic/transport@8.10.1", "", { "dependencies": { "@opentelemetry/api": "1.x", "@opentelemetry/core": "2.x", "debug": "^4.4.1", "hpagent": "^1.2.0", "ms": "^2.1.3", "secure-json-parse": "^3.0.1", "tslib": "^2.8.1", "undici": "^6.21.1" } }, "sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw=="],
+    "@elastic/transport": ["@elastic/transport@9.3.7", "", { "dependencies": { "@opentelemetry/api": "1.x", "@opentelemetry/core": "2.x", "debug": "^4.4.1", "hpagent": "^1.2.0", "ms": "^2.1.3", "secure-json-parse": "^4.0.0", "tslib": "^2.8.1", "undici": "^7.19.1" } }, "sha512-L38Ax21uF2OPUmCRWycZ/dZdMYf7gMrtClcxvVrqJVFmn8ET2M++GYmFGJpLqOHS1beATxOXLWe7y2ijSQz/ng=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -575,8 +575,6 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
-
     "@tsconfig/node10": ["@tsconfig/node10@1.0.12", "", {}, "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ=="],
 
     "@tsconfig/node12": ["@tsconfig/node12@1.0.11", "", {}, "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="],
@@ -588,10 +586,6 @@
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
-    "@types/command-line-args": ["@types/command-line-args@5.2.3", "", {}, "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="],
-
-    "@types/command-line-usage": ["@types/command-line-usage@5.0.4", "", {}, "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -721,8 +715,6 @@
 
     "ansis": ["ansis@4.3.1", "", {}, "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA=="],
 
-    "apache-arrow": ["apache-arrow@21.1.0", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^24.0.3", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-bignum": "^0.0.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.js" } }, "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA=="],
-
     "app-root-path": ["app-root-path@3.1.0", "", {}, "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA=="],
 
     "arcsecond": ["arcsecond@5.0.0", "", {}, "sha512-J/fHdyadnsIencRsM6oUSsraCKG+Ni9Udcgr/eusxjTzX3SEQtCUQSpP0YtImFPfIK6DdT1nqwN0ng4FqNmwgA=="],
@@ -730,8 +722,6 @@
     "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "array-back": ["array-back@6.2.3", "", {}, "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw=="],
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
@@ -807,8 +797,6 @@
 
     "chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
 
-    "chalk-template": ["chalk-template@0.4.0", "", { "dependencies": { "chalk": "^4.1.2" } }, "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg=="],
-
     "check-error": ["check-error@1.0.3", "", { "dependencies": { "get-func-name": "^2.0.2" } }, "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg=="],
 
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
@@ -834,10 +822,6 @@
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
-    "command-line-args": ["command-line-args@6.0.2", "", { "dependencies": { "array-back": "^6.2.3", "find-replace": "^5.0.2", "lodash.camelcase": "^4.3.0", "typical": "^7.3.0" }, "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ=="],
-
-    "command-line-usage": ["command-line-usage@7.0.4", "", { "dependencies": { "array-back": "^6.2.2", "chalk-template": "^0.4.0", "table-layout": "^4.1.1", "typical": "^7.3.0" } }, "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
@@ -991,11 +975,7 @@
 
     "find-cache-dir": ["find-cache-dir@2.1.0", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^2.0.0", "pkg-dir": "^3.0.0" } }, "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ=="],
 
-    "find-replace": ["find-replace@5.0.2", "", { "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q=="],
-
     "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
-
-    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
     "flow-parser": ["flow-parser@0.304.0", "", {}, "sha512-JjHRBxQX5b5pAn0nwr/U29U+uodOQzIyAKRAFEaXpB2BUkNyW76IRRD0eCEKvZGj23sJ+zDyPuwGGRGNwWW5vQ=="],
 
@@ -1134,8 +1114,6 @@
     "jscodeshift": ["jscodeshift@17.3.0", "", { "dependencies": { "@babel/core": "^7.24.7", "@babel/parser": "^7.24.7", "@babel/plugin-transform-class-properties": "^7.24.7", "@babel/plugin-transform-modules-commonjs": "^7.24.7", "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7", "@babel/plugin-transform-optional-chaining": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/preset-flow": "^7.24.7", "@babel/preset-typescript": "^7.24.7", "@babel/register": "^7.24.6", "flow-parser": "0.*", "graceful-fs": "^4.2.4", "micromatch": "^4.0.7", "neo-async": "^2.5.0", "picocolors": "^1.0.1", "recast": "^0.23.11", "tmp": "^0.2.3", "write-file-atomic": "^5.0.1" }, "peerDependencies": { "@babel/preset-env": "^7.1.6" }, "optionalPeers": ["@babel/preset-env"], "bin": { "jscodeshift": "bin/jscodeshift.js" } }, "sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
-
-    "json-bignum": ["json-bignum@0.0.3", "", {}, "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg=="],
 
     "json-query": ["json-query@2.2.2", "", {}, "sha512-y+IcVZSdqNmS4fO8t1uZF6RMMs0xh3SrTjJr9bp1X3+v0Q13+7Cyv12dSmKwDswp/H427BVtpkLWhGxYu3ZWRA=="],
 
@@ -1479,8 +1457,6 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "table-layout": ["table-layout@4.1.1", "", { "dependencies": { "array-back": "^6.2.2", "wordwrapjs": "^5.1.0" } }, "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA=="],
-
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
@@ -1527,11 +1503,9 @@
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "typical": ["typical@7.3.0", "", {}, "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw=="],
-
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
-    "undici": ["undici@6.24.0", "", {}, "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA=="],
+    "undici": ["undici@7.22.0", "", {}, "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -1562,8 +1536,6 @@
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
-
-    "wordwrapjs": ["wordwrapjs@5.1.1", "", {}, "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1761,12 +1733,6 @@
 
     "@better-auth/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
-    "@elastic/transport/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
-
-    "@elastic/transport/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
-
-    "@elastic/transport/secure-json-parse": ["secure-json-parse@3.0.2", "", {}, "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w=="],
-
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
     "@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
@@ -1881,17 +1847,11 @@
 
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
-    "apache-arrow/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
-
     "axios/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "axios-ntlm/axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
 
     "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "chalk-template/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "cheerio/undici": ["undici@7.22.0", "", {}, "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -2026,8 +1986,6 @@
     "@aws-sdk/middleware-user-agent/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.22", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.1", "fast-xml-parser": "5.7.2", "tslib": "^2.6.2" } }, "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA=="],
 
     "@aws-sdk/middleware-user-agent/@aws-sdk/core/@smithy/signature-v4": ["@smithy/signature-v4@5.3.14", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA=="],
-
-    "@elastic/transport/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
     "@grpc/grpc-js/@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/backend/config/deploy.prod.yml
+++ b/backend/config/deploy.prod.yml
@@ -88,7 +88,7 @@ accessories:
       - nadeshiko-postgres-data:/var/lib/postgresql/data
 
   elasticsearch:
-    image: ghcr.io/davafons/nadeshiko-elasticsearch:8.17.10
+    image: <%= ENV.fetch("ELASTICSEARCH_IMAGE", "ghcr.io/brigadasos/nadeshiko-elasticsearch:9.4.1-sudachi-3.6.0-dict-20260116") %>
     host: nadeshiko
     port: "100.95.40.11:9200:9200"
     env:
@@ -101,7 +101,9 @@ accessories:
         xpack.security.http.ssl.enabled: "false"
         http.host: "0.0.0.0"
     volumes:
-      - nadeshiko-elasticsearch-data:/usr/share/elasticsearch/data
+      # ES9 is rebuilt from PostgreSQL on a fresh volume. The ES8 volume is
+      # retained untouched through the rollback observation window.
+      - nadeshiko-elasticsearch-v9-data:/usr/share/elasticsearch/data
     cmd: >
       bash -c '
         export ELASTIC_PASSWORD="$ELASTICSEARCH_ADMIN_PASSWORD";

--- a/backend/config/deploy.staging.yml
+++ b/backend/config/deploy.staging.yml
@@ -54,7 +54,7 @@ env:
     POSTGRES_HOST: "nadeshiko-backend-prod-postgres"
     POSTGRES_PORT: 5432
 
-    ELASTICSEARCH_HOST: "http://nadeshiko-backend-prod-elasticsearch:9200"
+    ELASTICSEARCH_HOST: "http://nadeshiko-backend-stg-elasticsearch:9200"
     ELASTICSEARCH_INDEX: nadedb_dev
 
     R2_BASE_URL: https://cdn.nadeshiko.co
@@ -62,4 +62,32 @@ env:
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:4328"
     OTEL_SERVICE_NAME: nadeshiko-backend-stg
     OTEL_SEMCONV_STABILITY_OPT_IN: http
+
+accessories:
+  elasticsearch:
+    image: <%= ENV.fetch("ELASTICSEARCH_IMAGE", "ghcr.io/brigadasos/nadeshiko-elasticsearch:9.4.1-sudachi-3.6.0-dict-20260116") %>
+    host: nadeshiko
+    env:
+      secret:
+        - ELASTICSEARCH_ADMIN_PASSWORD
+      clear:
+        discovery.type: single-node
+        ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+        xpack.security.enabled: "true"
+        xpack.security.http.ssl.enabled: "false"
+        http.host: "0.0.0.0"
+    volumes:
+      - nadeshiko-elasticsearch-stg-v9-data:/usr/share/elasticsearch/data
+    cmd: >
+      bash -c '
+        export ELASTIC_PASSWORD="$ELASTICSEARCH_ADMIN_PASSWORD";
+        ./bin/elasticsearch
+      '
+    options:
+      # Isolated staging canary; sized for functional validation, not production load.
+      memory: 2g
+      memory-swap: 2.5g
+      ulimit:
+        - nofile=65536:65536
+        - memlock=-1:-1
 

--- a/backend/config/elasticsearch-client.ts
+++ b/backend/config/elasticsearch-client.ts
@@ -1,0 +1,4 @@
+export const ELASTICSEARCH_CLIENT_DEFAULTS = {
+  // The v9 client removed v8's 30-second default and otherwise waits indefinitely.
+  requestTimeout: 30_000,
+} as const;

--- a/backend/config/elasticsearch.ts
+++ b/backend/config/elasticsearch.ts
@@ -1,6 +1,7 @@
 import { Client, HttpConnection } from '@elastic/elasticsearch';
 import { config, type AppConfig } from '@config/config';
 import { logger } from '@config/log';
+import { ELASTICSEARCH_CLIENT_DEFAULTS } from '@config/elasticsearch-client';
 import elasticsearchSchema from 'config/elasticsearch-schema.json';
 import type { ReindexResponse } from '@app/models/segmentDocument/SegmentIndexer';
 
@@ -13,6 +14,7 @@ export const client = new Client({
     password: config.ELASTICSEARCH_PASSWORD,
   },
   Connection: HttpConnection,
+  ...ELASTICSEARCH_CLIENT_DEFAULTS,
 });
 
 /**
@@ -34,6 +36,7 @@ function createAdminClient(configValues: AppConfig): Client {
       password: adminPassword,
     },
     Connection: HttpConnection,
+    ...ELASTICSEARCH_CLIENT_DEFAULTS,
   });
 }
 

--- a/backend/docker/Dockerfile.elasticsearch
+++ b/backend/docker/Dockerfile.elasticsearch
@@ -1,10 +1,10 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:8.19.15@sha256:785913a22bd053dde1fb93d7098a1a58e0fc894cffc195752772c0d2682900ec
+FROM docker.elastic.co/elasticsearch/elasticsearch:9.4.1@sha256:268f65f1b32ea367e49c9be2acab144011b8c66c462c890f6190707743199050
 RUN bin/elasticsearch-plugin install analysis-icu
 # Sudachi 3.6 declares read access to config/sudachi; --batch accepts that
 # reviewed entitlement so image builds remain non-interactive.
 ADD --chown=elasticsearch:root --chmod=0644 \
-  --checksum=sha256:ba5f83df76ef26e47fc005df2c7614fee0f7318958edf261623b09e9d39621c3 \
-  https://github.com/WorksApplications/elasticsearch-sudachi/releases/download/v3.6.0/elasticsearch-8.19.15-analysis-sudachi-3.6.0.zip \
+  --checksum=sha256:ec46ddefc74743a4efd68f36af999ef39ed374312a82469f48690b271c32a1e6 \
+  https://github.com/WorksApplications/elasticsearch-sudachi/releases/download/v3.6.0/elasticsearch-9.4.1-analysis-sudachi-3.6.0.zip \
   /tmp/elasticsearch-analysis-sudachi.zip
 RUN bin/elasticsearch-plugin install --batch file:///tmp/elasticsearch-analysis-sudachi.zip && \
   rm /tmp/elasticsearch-analysis-sudachi.zip
@@ -12,11 +12,10 @@ USER root
 ADD --checksum=sha256:2a1eda5a0240a42f45daf8003d97df5565c5d252bb2d58e71807bbbd082f7eea \
   https://github.com/WorksApplications/SudachiDict/releases/download/v20260116/sudachi-dictionary-20260116-full.zip \
   /tmp/sudachi-dict-full.zip
-RUN apt-get update && apt-get install -y --no-install-recommends unzip && \
-  mkdir -p config/sudachi && \
+# Elasticsearch 9.4.1 is RHEL-based and already includes unzip.
+RUN mkdir -p config/sudachi && \
   unzip /tmp/sudachi-dict-full.zip -d /tmp/sudachi-dict && \
   mv /tmp/sudachi-dict/*/system_full.dic config/sudachi/system_core.dic && \
   chown -R elasticsearch:elasticsearch config/sudachi && \
-  rm -rf /tmp/sudachi-dict-full.zip /tmp/sudachi-dict && \
-  apt-get purge -y unzip && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+  rm -rf /tmp/sudachi-dict-full.zip /tmp/sudachi-dict
 USER elasticsearch

--- a/backend/docs/elasticsearch-9-migration.md
+++ b/backend/docs/elasticsearch-9-migration.md
@@ -1,0 +1,74 @@
+# Elasticsearch 9 migration
+
+Nadeshiko upgrades the JavaScript client from 8.19.2 to 9.4.2 and the custom server image from the 8.x line to Elasticsearch 9.4.1.
+
+## Why the server is 9.4.1
+
+Elasticsearch 9.4.4 is the newest upstream server release at the time of this change. Nadeshiko requires `analysis-sudachi`, and Sudachi 3.6.0 publishes exact Elasticsearch builds only through 9.4.1. Elasticsearch plugins must match the server version exactly. Therefore 9.4.1 is the newest safe server version currently available for Nadeshiko; moving to 9.4.4 is blocked until an exact Sudachi artifact exists and passes the same gates.
+
+The client can be 9.4.2 with server 9.4.1. This pairing passed the full backend suite and runtime search/analyzer gates.
+
+## Data strategy
+
+Production Elasticsearch contains a derived search index whose authoritative source is PostgreSQL. The release does **not** open the Elasticsearch 8 data directory with Elasticsearch 9:
+
+1. resolve reviewed, commit-bound Elasticsearch and backend tags to immutable digests;
+2. stop `kamal-proxy` and every production backend process, freezing API and worker writes;
+3. stop and rename the existing Elasticsearch 8 container while retaining `nadeshiko-elasticsearch-data` untouched;
+4. require that `nadeshiko-elasticsearch-v9-data` does not already exist, then boot Elasticsearch 9 on that fresh volume;
+5. run the new backend image as an unexposed one-off migration container and rebuild the index from PostgreSQL;
+6. verify cluster health, bulk-item success, counts, aliases, plugins, runtime version, and Japanese baseform analysis;
+7. deploy and expose the client-9 backend only after every migration gate passes;
+8. retain the stopped Elasticsearch 8 container and volume through the rollback observation window.
+
+This fresh-volume rebuild avoids an in-place, irreversible data-directory upgrade. The earlier 8.19.15 bridge image remains available for format/snapshot rehearsal, but production does not need to traverse it when no old Elasticsearch data directory is opened.
+
+## Compatibility and safety gates
+
+Validated before publication:
+
+- client 8.19.2 against server 9.4.1: pass;
+- client 9.4.2 against server 9.4.1: pass;
+- client 9 against server 8: rejected, so server migration precedes backend deployment;
+- full backend suite against Elasticsearch 9.4.1;
+- ICU and Sudachi plugin presence;
+- real Nadeshiko mappings and Japanese baseform query (`食べました` → `食べる`);
+- explicit 30-second timeout on every application/admin Elasticsearch client;
+- R2 S3-compatible snapshot/create/delete/restore drill;
+- Docker backend image contains the controlled DB/ES migration CLIs.
+- bulk item failures abort population and prevent the alias swap;
+- cluster readiness requires `timed_out=false` and yellow/green health, not merely HTTP 200.
+
+## Staging sequence
+
+A merge that changes Elasticsearch paths does not automatically deploy the backend. This avoids deploying client 9 while the isolated staging server is absent or still on Elasticsearch 8. Every later staging backend deployment also verifies the 9.4.1 server and both required plugins, so an unrelated merge cannot bypass the canary gate.
+
+After the Elasticsearch image publication workflow succeeds, dispatch `[Stg] Release` with `bootstrap_elasticsearch_canary=true`. The workflow:
+
+1. proves the semantic component tag and the Dockerfile-commit tag resolve to the same registry digest;
+2. recreates only the isolated staging Elasticsearch container on its fresh v9 volume;
+3. verifies Elasticsearch 9.4.1 plus ICU/Sudachi;
+4. deploys the client-9 backend;
+5. prepares/reindexes `nadedb_dev` from PostgreSQL;
+6. checks DB/ES count parity and Japanese analysis;
+7. runs the existing public staging E2E gate.
+
+Staging uses `nadeshiko-backend-stg-elasticsearch` and the fresh `nadeshiko-elasticsearch-stg-v9-data` volume; it no longer points at the production Elasticsearch container.
+
+## Production release and rollback
+
+Production changes only from the tagged `[Prod] Release` workflow. A normal merge does not run the production migration.
+
+The release validates the actual triggering tag (`GITHUB_REF_NAME`), requires its SHA to be on `main`, and proves the semantic Elasticsearch tag equals the Dockerfile-commit tag before using the resulting digest. It also resolves the release backend SHA tag to a digest. Kamal is forced to that exact release SHA, and the migration script requires every running production web container to report both the expected release version and the image ID obtained from the reviewed digest before accepting the deployment. Administrative SSM values are rejected if empty or if they contain CR/LF before a `0600` env file is created.
+
+The workflow and a host-side lock serialize migration attempts. The script fails closed unless the current container is Elasticsearch 8.19.15 on the expected old volume, the v9 volume is absent, the proxy is running, and the previous application version can be identified for an explicit Kamal rollback. It preserves the old Elasticsearch container under:
+
+```text
+nadeshiko-backend-prod-elasticsearch-es8-rollback
+```
+
+Before rebuilding, the script stops ingress and all backend processes. Therefore PostgreSQL and Elasticsearch cannot diverge during the copy or rollback window. If migration fails before application deployment, it removes only the new ES9 container, restores the unchanged ES8 container, and restarts the retained application/proxy stack. A failed v9 volume is deliberately retained for inspection and must be explicitly cleared before retrying.
+
+If Kamal deployment is attempted and fails, the script explicitly rolls the application back to the captured previous version while retaining the already-complete ES9 index. It does not restore a stale ES8 index after traffic may have resumed.
+
+After a successful release, do not delete the retained Elasticsearch 8 container or volume until the observation window and external E2E/telemetry review are complete. Any later operator-initiated return to ES8 requires another write freeze and an authoritative PostgreSQL reindex before traffic resumes; alias reversal alone is not data recovery.

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3.1095.0",
     "@better-auth/api-key": "^1.6.25",
-    "@elastic/elasticsearch": "^8.19.2",
+    "@elastic/elasticsearch": "^9.4.2",
     "@nahkies/typescript-express-runtime": "0.26.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.10.0",

--- a/backend/scripts/bootstrap-elasticsearch-staging-canary.sh
+++ b/backend/scripts/bootstrap-elasticsearch-staging-canary.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+admin_env=${1:?admin env file is required}
+es=nadeshiko-backend-stg-elasticsearch
+web=$(sudo -n docker ps --format '{{.Names}}' --filter name=nadeshiko-backend-stg-web | head -n1)
+test -n "$web"
+chmod 600 "$admin_env"
+
+for attempt in $(seq 1 90); do
+  health=$(sudo -n docker exec "$es" bash -c \
+    'curl --fail --silent --user "elastic:$ELASTICSEARCH_ADMIN_PASSWORD" http://localhost:9200/_cluster/health' \
+    2>/dev/null || true)
+  if grep -q '"timed_out":false' <<<"$health" && grep -Eq '"status":"(yellow|green)"' <<<"$health"; then
+    break
+  fi
+  if [ "$attempt" -eq 90 ]; then
+    sudo -n docker logs --tail 200 "$es"
+    exit 1
+  fi
+  sleep 2
+done
+
+version=$(sudo -n docker exec "$es" /usr/share/elasticsearch/bin/elasticsearch --version)
+grep -q 'Version: 9.4.1' <<<"$version"
+plugins=$(sudo -n docker exec "$es" /usr/share/elasticsearch/bin/elasticsearch-plugin list)
+grep -qx 'analysis-icu' <<<"$plugins"
+grep -qx 'analysis-sudachi' <<<"$plugins"
+
+sudo -n docker exec \
+  --env-file "$admin_env" \
+  --env ELASTICSEARCH_HOST=http://nadeshiko-backend-stg-elasticsearch:9200 \
+  "$web" node --import tsx bin/db.ts prepare
+sudo -n docker exec \
+  --env ELASTICSEARCH_HOST=http://nadeshiko-backend-stg-elasticsearch:9200 \
+  "$web" node --import tsx bin/es.ts reindex
+status=$(sudo -n docker exec \
+  --env ELASTICSEARCH_HOST=http://nadeshiko-backend-stg-elasticsearch:9200 \
+  "$web" node --import tsx bin/es.ts status 2>&1)
+grep -q 'Elasticsearch index is in sync with database segment count' <<<"$status"
+
+analyze=$(sudo -n docker exec "$es" bash -c '
+  curl --fail --silent --user "elastic:$ELASTICSEARCH_ADMIN_PASSWORD" \
+    --header "Content-Type: application/json" \
+    --data-binary '\''{"analyzer":"ja_baseform_search_analyzer","text":"食べました"}'\'' \
+    http://localhost:9200/nadedb_dev/_analyze
+')
+grep -q '"token":"食べる"' <<<"$analyze"
+
+echo ELASTICSEARCH_STAGING_CANARY_BOOTSTRAP=PASS

--- a/backend/scripts/migrate-elasticsearch-production.sh
+++ b/backend/scripts/migrate-elasticsearch-production.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+elasticsearch_image=${1:?immutable Elasticsearch image reference is required}
+backend_image=${2:?immutable backend image reference is required}
+release_version=${3:?release commit SHA is required}
+admin_env=${4:?admin env file is required}
+remote=${REMOTE_HOST:-nadeshiko}
+es=nadeshiko-backend-prod-elasticsearch
+rollback_es=nadeshiko-backend-prod-elasticsearch-es8-rollback
+expected_version=9.4.1
+remote_lock=/var/lock/nadeshiko-elasticsearch-9-migration.lock
+remote_stage=''
+locked=false
+frozen=false
+deployment_attempted=false
+previous_version=''
+previous_image_id=''
+
+case "$elasticsearch_image" in
+  ghcr.io/brigadasos/nadeshiko-elasticsearch@sha256:*) ;;
+  *) echo 'Elasticsearch image must be an immutable GHCR digest.' >&2; exit 1 ;;
+esac
+case "$backend_image" in
+  ghcr.io/brigadasos/nadeshiko-backend-prod@sha256:*) ;;
+  *) echo 'Backend image must be an immutable GHCR digest.' >&2; exit 1 ;;
+esac
+[[ "$release_version" =~ ^[0-9a-f]{40}$ ]]
+
+verify_running_application() {
+  local expected_version=$1 expected_image_id=$2
+  ssh "$remote" "
+    set -euo pipefail
+    found=false
+    while IFS= read -r container; do
+      found=true
+      case \"\$container\" in nadeshiko-backend-prod-web-*) ;; *) exit 1 ;; esac
+      actual_image_id=\$(sudo -n docker inspect \"\$container\" --format '{{.Image}}')
+      test \"\$actual_image_id\" = '$expected_image_id'
+      actual_version=\$(sudo -n docker inspect \"\$container\" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^KAMAL_VERSION=' | cut -d= -f2-)
+      test \"\$actual_version\" = '$expected_version'
+    done < <(sudo -n docker ps --format '{{.Names}}' --filter label=service=nadeshiko-backend-prod --filter label=destination=prod --filter label=role=web)
+    test \"\$found\" = true
+    test \"\$(sudo -n docker inspect kamal-proxy --format '{{.State.Running}}')\" = true
+  "
+}
+
+release_lock() {
+  if [ "$locked" = true ]; then
+    ssh "$remote" "sudo -n rmdir '$remote_lock'" >/dev/null 2>&1 || true
+    locked=false
+  fi
+}
+
+restore_frozen_es8_stack() {
+  ssh "$remote" "
+    set -euo pipefail
+    if sudo -n docker inspect '$rollback_es' >/dev/null 2>&1; then
+      sudo -n docker rm --force '$es' >/dev/null 2>&1 || true
+      sudo -n docker rename '$rollback_es' '$es'
+    fi
+    sudo -n docker start '$es' >/dev/null
+    while IFS= read -r container; do
+      case \"\$container\" in
+        nadeshiko-backend-prod-web-*) sudo -n docker start \"\$container\" >/dev/null ;;
+        *) echo \"Unexpected retained application container: \$container\" >&2; exit 1 ;;
+      esac
+    done < '$remote_stage/app-containers'
+    sudo -n docker start kamal-proxy >/dev/null
+  "
+}
+
+cleanup() {
+  rc=$?
+  trap - EXIT
+
+  if [ "$rc" -ne 0 ]; then
+    if [ "$deployment_attempted" = true ]; then
+      echo "Production deployment failed; rolling the application back explicitly to ${previous_version} while retaining the complete ES9 index." >&2
+      if ! kamal rollback "$previous_version" -d prod || ! verify_running_application "$previous_version" "$previous_image_id"; then
+        echo 'Application rollback or its running-container verification failed. Elasticsearch 9 remains active; traffic requires operator intervention.' >&2
+      fi
+    elif [ "$frozen" = true ]; then
+      echo 'Elasticsearch migration failed during the write freeze; restoring the unchanged ES8 application stack.' >&2
+      restore_frozen_es8_stack || echo 'Automatic ES8 stack restoration failed; operator intervention is required.' >&2
+    fi
+  fi
+
+  if [ -n "$remote_stage" ]; then
+    ssh "$remote" "sudo -n rm -rf '$remote_stage'" >/dev/null 2>&1 || true
+  fi
+  release_lock
+  exit "$rc"
+}
+trap cleanup EXIT
+
+read_health() {
+  ssh "$remote" "sudo -n docker exec '$es' bash -c 'curl --fail --silent --user \"elastic:\$ELASTICSEARCH_ADMIN_PASSWORD\" http://localhost:9200/_cluster/health'"
+}
+
+wait_for_healthy_cluster() {
+  local health=''
+  for attempt in $(seq 1 90); do
+    health=$(read_health 2>/dev/null || true)
+    if grep -q '"timed_out":false' <<<"$health" && grep -Eq '"status":"(yellow|green)"' <<<"$health"; then
+      return 0
+    fi
+    if [ "$attempt" -eq 90 ]; then
+      ssh "$remote" "sudo -n docker logs --tail 200 '$es'"
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+verify_es9() {
+  local version plugins actual_image
+  wait_for_healthy_cluster
+  version=$(ssh "$remote" "sudo -n docker exec '$es' /usr/share/elasticsearch/bin/elasticsearch --version")
+  grep -q "Version: ${expected_version}" <<<"$version"
+  plugins=$(ssh "$remote" "sudo -n docker exec '$es' /usr/share/elasticsearch/bin/elasticsearch-plugin list")
+  grep -qx analysis-icu <<<"$plugins"
+  grep -qx analysis-sudachi <<<"$plugins"
+  actual_image=$(ssh "$remote" "sudo -n docker inspect '$es' --format '{{.Config.Image}}'")
+  test "$actual_image" = "$elasticsearch_image"
+}
+
+current_version=''
+if ssh "$remote" "sudo -n docker inspect '$es' >/dev/null 2>&1"; then
+  current_version=$(ssh "$remote" "sudo -n docker exec '$es' /usr/share/elasticsearch/bin/elasticsearch --version" || true)
+fi
+
+printf '%s' "${GITHUB_TOKEN:?GITHUB_TOKEN is required}" | \
+  ssh "$remote" "sudo -n docker login ghcr.io --username '${GITHUB_ACTOR:?GITHUB_ACTOR is required}' --password-stdin >/dev/null"
+ssh "$remote" "sudo -n docker pull '$backend_image' >/dev/null"
+expected_backend_id=$(ssh "$remote" "sudo -n docker image inspect '$backend_image' --format '{{.Id}}'")
+[[ "$expected_backend_id" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+# Future releases only verify the already-migrated accessory and deploy normally.
+if grep -q "Version: ${expected_version}" <<<"$current_version"; then
+  verify_es9
+  VERSION="$release_version" kamal deploy -d prod --skip-push
+  verify_running_application "$release_version" "$expected_backend_id"
+  trap - EXIT
+  echo ELASTICSEARCH_PRODUCTION_ALREADY_MIGRATED=PASS
+  exit 0
+fi
+
+grep -q 'Version: 8.19.15' <<<"$current_version"
+ssh "$remote" "sudo -n mkdir '$remote_lock'"
+locked=true
+ssh "$remote" "! sudo -n docker inspect '$rollback_es' >/dev/null 2>&1"
+ssh "$remote" "! sudo -n docker volume inspect nadeshiko-elasticsearch-v9-data >/dev/null 2>&1"
+old_mounts=$(ssh "$remote" "sudo -n docker inspect '$es' --format '{{range .Mounts}}{{println .Name .Destination}}{{end}}'")
+grep -qx 'nadeshiko-elasticsearch-data /usr/share/elasticsearch/data' <<<"$old_mounts"
+
+old_web=$(ssh "$remote" "sudo -n docker ps --format '{{.Names}}' --filter name=nadeshiko-backend-prod-web | head -n1")
+case "$old_web" in
+  nadeshiko-backend-prod-web-*) ;;
+  *) echo 'Unable to identify the running production web container.' >&2; exit 1 ;;
+esac
+previous_version=$(ssh "$remote" "sudo -n docker inspect '$old_web' --format '{{index .Config.Labels \"version\"}}'")
+if [ -z "$previous_version" ]; then
+  previous_version=${old_web#nadeshiko-backend-prod-web-}
+fi
+test -n "$previous_version"
+previous_image_id=$(ssh "$remote" "sudo -n docker inspect '$old_web' --format '{{.Image}}'")
+[[ "$previous_image_id" =~ ^sha256:[0-9a-f]{64}$ ]]
+network=$(ssh "$remote" "sudo -n docker inspect '$old_web' --format '{{range \$name, \$_ := .NetworkSettings.Networks}}{{println \$name}}{{end}}' | head -n1")
+test -n "$network"
+ssh "$remote" "test \"\$(sudo -n docker inspect kamal-proxy --format '{{.State.Running}}')\" = true"
+
+remote_stage=$(ssh "$remote" "sudo -n mktemp -d /var/tmp/nadeshiko-es9-migration.XXXXXX")
+ssh "$remote" "
+  set -euo pipefail
+  sudo -n sh -c \"docker ps --format '{{.Names}}' --filter name=nadeshiko-backend-prod-web > '$remote_stage/app-containers'\"
+  test -s '$remote_stage/app-containers'
+  while IFS= read -r container; do
+    case \"\$container\" in nadeshiko-backend-prod-web-*) ;; *) exit 1 ;; esac
+  done < '$remote_stage/app-containers'
+  sudo -n sh -c \"docker inspect '$old_web' --format '{{range .Config.Env}}{{println .}}{{end}}' > '$remote_stage/app.env'\"
+  sudo -n chmod 600 '$remote_stage/app.env'
+"
+ssh "$remote" "sudo -n tee '$remote_stage/admin.env' >/dev/null && sudo -n chmod 600 '$remote_stage/admin.env'" <"$admin_env"
+
+# Hard maintenance window: stop ingress first, then every process that can mutate
+# PostgreSQL/Elasticsearch. The old containers remain intact for rollback.
+ssh "$remote" "
+  set -euo pipefail
+  sudo -n docker stop kamal-proxy >/dev/null
+  while IFS= read -r container; do sudo -n docker stop \"\$container\" >/dev/null; done < '$remote_stage/app-containers'
+"
+frozen=true
+
+ssh "$remote" "sudo -n docker stop '$es' >/dev/null; sudo -n docker rename '$es' '$rollback_es'"
+ELASTICSEARCH_IMAGE="$elasticsearch_image" kamal accessory boot elasticsearch -d prod
+verify_es9
+
+ssh "$remote" "sudo -n docker run --rm --network '$network' --env-file '$remote_stage/app.env' --env-file '$remote_stage/admin.env' '$backend_image' node --import tsx bin/db.ts prepare-es"
+ssh "$remote" "sudo -n docker run --rm --network '$network' --env-file '$remote_stage/app.env' --env-file '$remote_stage/admin.env' '$backend_image' node --import tsx bin/es.ts reindex --allow-prod-destructive"
+status=$(ssh "$remote" "sudo -n docker run --rm --network '$network' --env-file '$remote_stage/app.env' --env-file '$remote_stage/admin.env' '$backend_image' node --import tsx bin/es.ts status" 2>&1)
+grep -q 'Elasticsearch index is in sync with database segment count' <<<"$status"
+
+analyze=$(ssh "$remote" "sudo -n docker exec '$es' bash -c 'curl --fail --silent --user \"elastic:\$ELASTICSEARCH_ADMIN_PASSWORD\" --header \"Content-Type: application/json\" --data-binary '\''{\"analyzer\":\"ja_baseform_search_analyzer\",\"text\":\"食べました\"}'\'' http://localhost:9200/nadedb_prod/_analyze'")
+grep -q '"token":"食べる"' <<<"$analyze"
+
+# Only expose the new application after the authoritative rebuild and all gates pass.
+deployment_attempted=true
+VERSION="$release_version" kamal deploy -d prod --skip-push
+verify_running_application "$release_version" "$expected_backend_id"
+deployment_attempted=false
+frozen=false
+
+ssh "$remote" "sudo -n rm -rf '$remote_stage'"
+remote_stage=''
+release_lock
+trap - EXIT
+
+echo "ELASTICSEARCH_PRODUCTION_MIGRATION=PASS retained_rollback_container=${rollback_es} previous_app_version=${previous_version}"

--- a/backend/tests/config/elasticsearch.test.ts
+++ b/backend/tests/config/elasticsearch.test.ts
@@ -12,6 +12,7 @@ const mockIndicesGet = vi.fn();
 const mockIndicesCreate = vi.fn();
 const mockIndicesDelete = vi.fn();
 const mockIndicesUpdateAliases = vi.fn();
+const mockIndicesRefresh = vi.fn();
 
 vi.mock('@elastic/elasticsearch', () => {
   class MockClient {
@@ -31,6 +32,7 @@ vi.mock('@elastic/elasticsearch', () => {
       create: (...args: unknown[]) => mockIndicesCreate(...args),
       delete: (...args: unknown[]) => mockIndicesDelete(...args),
       updateAliases: (...args: unknown[]) => mockIndicesUpdateAliases(...args),
+      refresh: (...args: unknown[]) => mockIndicesRefresh(...args),
     };
   }
 
@@ -60,9 +62,11 @@ vi.mock('@config/log', () => ({
 const {
   INDEX_NAME,
   initializeElasticsearchIndexWithClient,
+  reindexZeroDowntime,
   resetElasticsearchIndexWithClient,
   setupElasticsearchUser,
 } = await import('@config/elasticsearch');
+const { ELASTICSEARCH_CLIENT_DEFAULTS } = await import('@config/elasticsearch-client');
 const { config } = await import('@config/config');
 
 function makeMockClient() {
@@ -75,6 +79,7 @@ function makeMockClient() {
       create: mockIndicesCreate,
       delete: mockIndicesDelete,
       updateAliases: mockIndicesUpdateAliases,
+      refresh: mockIndicesRefresh,
     },
     security: {
       deleteUser: mockDeleteUser,
@@ -107,6 +112,7 @@ beforeEach(() => {
   mockIndicesCreate.mockResolvedValue(undefined);
   mockIndicesDelete.mockResolvedValue(undefined);
   mockIndicesUpdateAliases.mockResolvedValue(undefined);
+  mockIndicesRefresh.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -114,6 +120,10 @@ afterEach(() => {
 });
 
 describe('setupElasticsearchUser', () => {
+  it('preserves the Elasticsearch v8 default request timeout explicitly', () => {
+    expect(ELASTICSEARCH_CLIENT_DEFAULTS).toEqual({ requestTimeout: 30_000 });
+  });
+
   it('skips setup when ELASTICSEARCH_ADMIN_PASSWORD is missing', async () => {
     const configValues = makeConfig({
       ELASTICSEARCH_ADMIN_PASSWORD: undefined,
@@ -266,5 +276,22 @@ describe('resetElasticsearchIndexWithClient', () => {
 
     expect(mockIndicesDelete).not.toHaveBeenCalled();
     expect(mockIndicesCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('reindexZeroDowntime', () => {
+  it('does not swap the alias when population reports bulk failures', async () => {
+    mockIndicesGetAlias.mockResolvedValue({ [`${INDEX_NAME}_v1`]: {} });
+    const populate = vi.fn().mockResolvedValue({
+      success: false,
+      message: 'Reindex completed with 1 failed document(s)',
+      stats: { totalSegments: 1, successfulIndexes: 0, failedIndexes: 1, mediaProcessed: 1 },
+      errors: [{ segmentId: 1, error: 'mapper failure' }],
+    });
+
+    await expect(reindexZeroDowntime(populate, makeMockClient() as any)).rejects.toThrow('Reindex population failed');
+
+    expect(mockIndicesUpdateAliases).not.toHaveBeenCalled();
+    expect(mockIndicesDelete).toHaveBeenCalledWith({ index: `${INDEX_NAME}_v2` });
   });
 });

--- a/backend/tests/models/mediaAudit/checks/dbEsSyncIssues.test.ts
+++ b/backend/tests/models/mediaAudit/checks/dbEsSyncIssues.test.ts
@@ -48,6 +48,33 @@ describe('dbEsSyncIssues check', () => {
     expect(results).toHaveLength(0);
   });
 
+  it('uses top-level aggregations accepted by the Elasticsearch 9 client', async () => {
+    let searchParams: unknown;
+    const esClient = {
+      search: async (params: unknown) => {
+        searchParams = params;
+        return { aggregations: { media: { buckets: [] } } };
+      },
+    } as unknown as Client;
+
+    await dbEsSyncIssues.run({
+      threshold: { minDifference: 5 },
+      dataSource: TestDataSource,
+      esClient,
+    });
+
+    expect(searchParams).toEqual({
+      index: '_all',
+      size: 0,
+      aggs: {
+        media: {
+          terms: { field: 'mediaId', size: 10000 },
+        },
+      },
+    });
+    expect((searchParams as { body?: unknown }).body).toBeUndefined();
+  });
+
   it('flags media where DB and ES counts diverge beyond threshold', async () => {
     const media = createMedia({ nameRomaji: 'Out of Sync', segmentCount: 100 });
     await media.save();

--- a/backend/tests/models/segmentDocument/SegmentIndexer.test.ts
+++ b/backend/tests/models/segmentDocument/SegmentIndexer.test.ts
@@ -101,4 +101,23 @@ describe('SegmentIndexer.reindex', () => {
     expect(createQueryBuilderSpy).toHaveBeenCalledTimes(3);
     expect(bulkIndexSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('returns failure when any bulk item fails', async () => {
+    vi.spyOn(Segment, 'createQueryBuilder').mockImplementation(() => {
+      return createSegmentQueryBuilderMock((state) =>
+        Number(state.params.lastId ?? 0) === 0 ? [{ id: 1, mediaId: 10, contentJa: 'a' }] : [],
+      ) as any;
+    });
+    vi.spyOn(SegmentIndexer, 'bulkIndex').mockResolvedValue({
+      succeeded: 0,
+      failed: 1,
+      errors: [{ segmentId: 1, error: 'mapper failure' }],
+    });
+
+    const result = await SegmentIndexer.reindex();
+
+    expect(result.success).toBe(false);
+    expect(result.stats.failedIndexes).toBe(1);
+    expect(result.errors).toEqual([{ segmentId: 1, error: 'mapper failure' }]);
+  });
 });


### PR DESCRIPTION
## Summary

Completes the Elasticsearch 9 migration in one coordinated PR:

- custom Elasticsearch server image: `8.19.15` → `9.4.1`;
- JavaScript client: `@elastic/elasticsearch 8.19.2` → `9.4.2`;
- exact `analysis-sudachi 3.6.0` build for Elasticsearch 9.4.1;
- pinned linux/amd64 base-image digest and SHA-256-pinned plugin/dictionary downloads;
- client-v9 request-shape fix for media-audit aggregations;
- explicit 30-second timeout shared by every application/admin client;
- isolated staging Elasticsearch container, host, and volume;
- manual staging canary gate before the client-9 backend can deploy;
- tagged production-release migration using a fresh ES9 volume and PostgreSQL reindex;
- hard production write freeze while the authoritative PostgreSQL rebuild runs;
- bulk-item failures abort population before the alias can swap;
- retained ES8 container and volume for rollback; no in-place downgrade/opening of the old volume;
- release runbook and runtime verification for version, plugins, counts, aliases, and Japanese baseform analysis.

## Version ceiling

Elasticsearch `9.4.4` is the newest upstream server release today. Nadeshiko requires Sudachi, whose current `3.6.0` release publishes exact Elasticsearch artifacts only through `9.4.1`. Elasticsearch plugins must exactly match the server. Therefore `9.4.1` is the latest safe server for Nadeshiko until Sudachi publishes a newer exact build. The npm client is at its current latest, `9.4.2`.

## Deployment behavior

- A normal merge does **not** modify production.
- A merge touching Elasticsearch paths also does not auto-deploy client 9 to staging; it waits for an explicit canary dispatch after the server image is published.
- `[Stg] Release` with `bootstrap_elasticsearch_canary=true` proves the semantic and Dockerfile-commit image tags resolve to the same digest, boots the isolated ES9 accessory, and validates health/version/plugins before client 9 can deploy. It then rebuilds `nadedb_dev`, validates Japanese analysis/count parity, and runs public E2E.
- Production changes only in the existing tagged `[Prod] Release` workflow.
- Production stops ingress and all backend processes before replacing Elasticsearch, rebuilds through an unexposed commit-bound backend image, and exposes client 9 only after all gates pass.
- Production ES9 uses `nadeshiko-elasticsearch-v9-data`; the old `nadeshiko-elasticsearch-data` volume is never deleted or opened by ES9.
- Pre-deploy failure restores the unchanged ES8 stack while writes are still frozen; deployment failure rolls back explicitly to the captured application version while retaining the complete ES9 index.

## Verification

- exact Sudachi 9.4.1 artifact availability/checksum: pass;
- npm latest client check: `9.4.2`;
- Sudachi maximum exact ES9 build: `9.4.1`;
- actionlint (image, staging, production workflows): pass;
- bash syntax + ShellCheck warning threshold: pass;
- rendered Kamal YAML and isolated volume assertions: pass;
- added-line secret/dangerous-code scan: 0 findings;
- `git diff --check`: pass;
- R2 S3-compatible snapshot/create/delete/restore drill: pass;
- `bun audit` versus `origin/main`: 0 new advisories, 4 advisories removed (pre-existing tree still has advisories, so the command remains nonzero);
- consolidated ES9/client9 publication gate: 722 passed, 0 failed across 63 files;
- data-directory upgrade gate, ES9 ICU/Sudachi Japanese integration, generated API/typecheck, and backend Docker build: pass;
- deterministic migration harness: success, pre-deploy ES8 restoration, explicit-version deployment rollback, and already-migrated release paths pass;
- independent fail-closed reviews of client/staging and production migration: approved.

## Release notes

Full sequencing and rollback semantics are documented in `backend/docs/elasticsearch-9-migration.md`.

Supersedes Dependabot PR #444; that PR updates only the package and does not coordinate server, plugin, staging, data, or release ordering.
