### PR TITLE
fix(ci): use deploy SSH user for staging

### DIFF
--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -112,6 +112,7 @@ jobs:
           mkdir -p ~/.ssh
           cat >> ~/.ssh/config <<'EOF'
           Host nadeshiko
+            User docker
             ProxyCommand tailscale nc %h %p
           EOF
           chmod 700 ~/.ssh
@@ -206,6 +207,7 @@ jobs:
           mkdir -p ~/.ssh
           cat >> ~/.ssh/config <<'EOF'
           Host nadeshiko
+            User docker
             ProxyCommand tailscale nc %h %p
           EOF
           chmod 700 ~/.ssh
@@ -321,6 +323,7 @@ jobs:
           mkdir -p ~/.ssh
           cat >> ~/.ssh/config <<'EOF'
           Host nadeshiko
+            User docker
             ProxyCommand tailscale nc %h %p
           EOF
           chmod 700 ~/.ssh


### PR DESCRIPTION
## Cause

The Elasticsearch staging canary used plain `ssh nadeshiko`, so OpenSSH inherited the GitHub-hosted runner account (`runner`). Tailscale SSH correctly denied that identity even though Kamal succeeded with the configured deploy account (`docker`).

## Fix

Set `User docker` in all three staging SSH config blocks so direct probes and Kamal use the same reviewed deploy identity.

## Evidence

- Failed canary run: https://github.com/BrigadaSOS/Nadeshiko/actions/runs/30491002449
- Exact failure: `tailnet policy does not permit you to SSH as user "runner"`
- Regression gate: 0/3 SSH blocks declared `docker` before; 3/3 after
- actionlint 1.7.12: pass
- `git diff --check`: pass

The backend deploy remained skipped by the existing fail-closed gate. The canary container was created by Kamal before the post-boot identity check failed.