### PR TITLE
fix(staging): initialize Elasticsearch bootstrap password

### DIFF
--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -245,6 +245,12 @@ jobs:
               ssh nadeshiko 'docker rm --force nadeshiko-backend-stg-elasticsearch >/dev/null'
               cd backend
               ELASTICSEARCH_IMAGE="$expected" kamal accessory boot elasticsearch -d staging
+            elif ! ssh nadeshiko 'docker inspect nadeshiko-backend-stg-elasticsearch --format "{{range .Config.Env}}{{println .}}{{end}}" | grep -q "^ELASTIC_PASSWORD="'; then
+              # Recreate only the container so the official entrypoint and
+              # bootstrap environment apply; preserve the named data volume.
+              ssh nadeshiko 'docker rm --force nadeshiko-backend-stg-elasticsearch >/dev/null'
+              cd backend
+              ELASTICSEARCH_IMAGE="$expected" kamal accessory boot elasticsearch -d staging
             elif [ "$(ssh nadeshiko 'docker inspect nadeshiko-backend-stg-elasticsearch --format "{{.State.Running}}"')" != true ]; then
               ssh nadeshiko 'docker start nadeshiko-backend-stg-elasticsearch >/dev/null'
             fi
@@ -255,6 +261,37 @@ jobs:
 
           actual=$(ssh nadeshiko 'docker inspect nadeshiko-backend-stg-elasticsearch --format "{{.Config.Image}}"')
           test "$actual" = "$expected"
+
+          # Wait until the HTTP security layer is ready. A secured node answers
+          # unauthenticated requests with 401; 200 also supports security-off
+          # diagnostics without weakening the authenticated health gate below.
+          for attempt in $(seq 1 90); do
+            http_status=$(ssh nadeshiko "docker exec nadeshiko-backend-stg-elasticsearch bash -c 'curl --silent --output /dev/null --write-out \"%{http_code}\" http://localhost:9200/_cluster/health'" 2>/dev/null || true)
+            if [ "$http_status" = 401 ] || [ "$http_status" = 200 ]; then
+              break
+            fi
+            if [ "$attempt" -eq 90 ]; then
+              ssh nadeshiko 'docker logs --tail 200 nadeshiko-backend-stg-elasticsearch'
+              exit 1
+            fi
+            sleep 2
+          done
+
+          health=$(ssh nadeshiko "docker exec nadeshiko-backend-stg-elasticsearch bash -c 'curl --fail --silent --user \"elastic:\$ELASTICSEARCH_ADMIN_PASSWORD\" http://localhost:9200/_cluster/health'" 2>/dev/null || true)
+          if ! grep -q '"timed_out":false' <<<"$health"; then
+            # Volumes initialized before ELASTIC_PASSWORD reached the official
+            # entrypoint have an unknown generated password. Reconcile only the
+            # built-in elastic user through Elasticsearch's supported tool;
+            # never delete the persistent volume to repair credentials.
+            ssh nadeshiko 'bash -s' <<'REMOTE'
+          set -euo pipefail
+          docker exec nadeshiko-backend-stg-elasticsearch bash -ceu '
+            test -n "$ELASTICSEARCH_ADMIN_PASSWORD"
+            printf "%s\n%s\n" "$ELASTICSEARCH_ADMIN_PASSWORD" "$ELASTICSEARCH_ADMIN_PASSWORD" |
+              ./bin/elasticsearch-reset-password --username elastic --interactive --batch >/dev/null
+          '
+          REMOTE
+          fi
 
           for attempt in $(seq 1 90); do
             health=$(ssh nadeshiko "docker exec nadeshiko-backend-stg-elasticsearch bash -c 'curl --fail --silent --user \"elastic:\$ELASTICSEARCH_ADMIN_PASSWORD\" http://localhost:9200/_cluster/health'" 2>/dev/null || true)

--- a/backend/.kamal/secrets.staging
+++ b/backend/.kamal/secrets.staging
@@ -30,6 +30,9 @@ ELASTICSEARCH_USER=$(.kamal/ssm-secret staging ELASTICSEARCH_USER)
 ELASTICSEARCH_PASSWORD=$(.kamal/ssm-secret staging ELASTICSEARCH_PASSWORD)
 ELASTICSEARCH_ADMIN_USER=$(.kamal/ssm-secret staging ELASTICSEARCH_ADMIN_USER)
 ELASTICSEARCH_ADMIN_PASSWORD=$(.kamal/ssm-secret staging ELASTICSEARCH_ADMIN_PASSWORD)
+# The official Elasticsearch entrypoint consumes ELASTIC_PASSWORD when it
+# initializes bootstrap.password. Keep the application-facing name as well.
+ELASTIC_PASSWORD=$(.kamal/ssm-secret staging ELASTICSEARCH_ADMIN_PASSWORD)
 DISCORD_CLIENT_ID=$(.kamal/ssm-secret staging DISCORD_CLIENT_ID)
 DISCORD_CLIENT_SECRET=$(.kamal/ssm-secret staging DISCORD_CLIENT_SECRET)
 ID_OAUTH_GOOGLE=$(.kamal/ssm-secret staging ID_OAUTH_GOOGLE)

--- a/backend/config/deploy.staging.yml
+++ b/backend/config/deploy.staging.yml
@@ -70,6 +70,7 @@ accessories:
     env:
       secret:
         - ELASTICSEARCH_ADMIN_PASSWORD
+        - ELASTIC_PASSWORD
       clear:
         discovery.type: single-node
         ES_JAVA_OPTS: "-Xms512m -Xmx512m"
@@ -78,11 +79,6 @@ accessories:
         http.host: "0.0.0.0"
     volumes:
       - nadeshiko-elasticsearch-stg-v9-data:/usr/share/elasticsearch/data
-    cmd: >
-      bash -c '
-        export ELASTIC_PASSWORD="$ELASTICSEARCH_ADMIN_PASSWORD";
-        ./bin/elasticsearch
-      '
     options:
       # Isolated staging canary; sized for functional validation, not production load.
       memory: 2g


### PR DESCRIPTION
## Summary
- preserve Elasticsearch's official Docker entrypoint and provide its required `ELASTIC_PASSWORD`
- recreate stale containers without deleting the named data volume
- reconcile the built-in `elastic` password for volumes initialized by the bypassed entrypoint

## Root cause
The staging accessory overrode the image command with `bash -c`. Elasticsearch 9.4.1's official entrypoint only installs `bootstrap.password` when invoked through its normal `elasticsearch` command path, so the configured admin password never became the built-in `elastic` password.

## Safety
- never removes `nadeshiko-elasticsearch-stg-v9-data`
- only recreates the accessory container when the required bootstrap environment is absent
- waits for the HTTP security layer before reconciliation
- uses Elasticsearch's supported `elasticsearch-reset-password` tool
- keeps authenticated health, version, ICU, and Sudachi gates fail-closed

## Validation
- bootstrap-password contract gate: pass
- YAML parse: pass
- Bash syntax: pass
- ShellCheck 0.11.0: pass with only the expected unused-assignment exemption for Kamal's externally consumed secrets file
- actionlint 1.7.12 + ShellCheck, scoped to staging workflow: pass
- `git diff --check`: pass
