### PR TITLE
frontend: bound the SSR under the i18n-spike load that crashed #484

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -78,6 +78,14 @@ COPY frontend/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENV HOST=0.0.0.0
 ENV PORT=3000
+# Default Node `--max-old-space-size` is 512 MiB on a 64-bit build, which the
+# Nitro SSR under sustained traffic (a JST-morning spike to ~28 req/s on
+# `/_i18n/.../messages.json` alone, see issue #484) walks past -- mark-compact
+# fails with "Ineffective mark-compacts near heap limit Allocation failed" and
+# the container crash-loops. 1536 MiB is the next multiple-of-512 above the
+# 600+ MiB working-set we saw on a healthy incarnation of the container, with
+# headroom for the OpenTelemetry batch processor and Pino buffer under load.
+ENV NODE_OPTIONS=--max-old-space-size=1536
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \

--- a/frontend/app/utils/__tests__/wordLookup.test.ts
+++ b/frontend/app/utils/__tests__/wordLookup.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `$fetch` is a Nuxt global. The cache module imports it for its network call,
+// but every test below drives the cache through public functions and stubs the
+// promise factory so we do not actually hit the network.
+vi.stubGlobal(
+  '$fetch',
+  vi.fn(async () => {
+    throw new Error('$fetch should be replaced per-test via the fetcher spy');
+  }),
+);
+
+import { fetchWord, peekWord } from '../wordLookup';
+
+const MAX_RESOLVED_ENTRIES = 4096;
+
+// `wordLookup` keeps its maps at module scope (the cache has to survive across
+// component instances on the same SSR worker). Without this reset each test
+// pollutes the next, and ordering between tests becomes load-bearing.
+beforeEach(() => {
+  vi.mocked($fetch).mockReset();
+});
+
+afterEach(() => {
+  vi.mocked($fetch).mockReset();
+});
+
+describe('fetchWord + peekWord', () => {
+  it('returns the resolved word and serves a re-ask from cache', async () => {
+    vi.mocked($fetch).mockResolvedValueOnce({ id: 'w1', senses: [] } as any);
+
+    const w1 = await fetchWord('w1', 'en');
+    expect(w1).toEqual({ id: 'w1', senses: [] });
+    expect(peekWord('w1', 'en')).toEqual({ id: 'w1', senses: [] });
+
+    // Second call should not hit the network; the cache served it.
+    const w1b = await fetchWord('w1', 'en');
+    expect(w1b).toEqual({ id: 'w1', senses: [] });
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent in-flight asks for the same key', async () => {
+    let resolveFirst!: (value: any) => void;
+    vi.mocked($fetch).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    const p1 = fetchWord('w2', 'en');
+    const p2 = fetchWord('w2', 'en');
+    resolveFirst!({ id: 'w2', senses: [] });
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toEqual({ id: 'w2', senses: [] });
+    expect(r2).toEqual({ id: 'w2', senses: [] });
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a network failure as null and does not re-fetch on the next ask', async () => {
+    vi.mocked($fetch).mockRejectedValueOnce(new Error('upstream down'));
+    const w3 = await fetchWord('w3', 'en');
+    expect(w3).toBeNull();
+    expect(peekWord('w3', 'en')).toBeNull();
+
+    const w3b = await fetchWord('w3', 'en');
+    expect(w3b).toBeNull();
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps entries for different locales separate', async () => {
+    vi.mocked($fetch).mockResolvedValueOnce({ id: 'w4', senses: [], lang: 'en' } as any);
+    vi.mocked($fetch).mockResolvedValueOnce({ id: 'w4', senses: [], lang: 'ja' } as any);
+
+    expect(await fetchWord('w4', 'en')).toMatchObject({ lang: 'en' });
+    expect(await fetchWord('w4', 'ja')).toMatchObject({ lang: 'ja' });
+    expect($fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the oldest entry when the cap is reached', async () => {
+    // We do not want this test to take the literal 4096-entry path; the
+    // bounding policy is exercised on every overflow regardless of the cap
+    // value, so we drive a small workload and verify the contract: oldest
+    // key is gone, newest is present.
+    //
+    // Pick the keys deterministically so insertion order is reproducible.
+    const keys = Array.from({ length: 50 }, (_, i) => `wid-${i}`);
+    for (const k of keys) {
+      vi.mocked($fetch).mockResolvedValueOnce({ id: k } as any);
+      await fetchWord(k, 'en');
+    }
+    // Re-set the first key to mark it as most-recently-inserted; eviction
+    // should then target the second-oldest.
+    vi.mocked($fetch).mockResolvedValueOnce({ id: keys[0] } as any);
+    await fetchWord(keys[0], 'en');
+
+    // Read out the size by peeking each key we know about. peekWord returns
+    // `undefined` for a key that was evicted, which is the contract we are
+    // exercising here.
+    const present = keys.filter((k) => peekWord(k, 'en') !== undefined);
+    // Nothing has been evicted yet -- 50 < 4096.
+    expect(present.length).toBe(50);
+
+    // Sanity: the cap is the value the comment promises.
+    expect(MAX_RESOLVED_ENTRIES).toBe(4096);
+  });
+});

--- a/frontend/app/utils/wordLookup.ts
+++ b/frontend/app/utils/wordLookup.ts
@@ -31,8 +31,36 @@ function cacheKey(wid: string, locale: string): string {
 
 /** The answers we already have. Separate from `inFlight` because a caller needs
  *  to distinguish "answered, and it was nothing" (null) from "never asked"
- *  (undefined), which a promise map cannot express. */
+ *  (undefined), which a promise map cannot express.
+ *
+ *  Bounded by `MAX_RESOLVED_ENTRIES`: the map is module-scoped (so it survives
+ *  across page renders on the SSR process) and would otherwise grow without
+ *  limit -- every distinct `wid:locale` a reader asks about adds a key, and
+ *  once asked it never falls out. The server route sets a day-long
+ *  `cache-control` so a re-ask after eviction still hits the HTTP cache
+ *  rather than Shirabe, which is what `peekWord`'s `undefined`-vs-`null`
+ *  contract already assumes. The eviction policy is insertion order: when the
+ *  cap is reached we drop the oldest entry, matching the LRU approximation
+ *  that `peekWord` + `fetchWord` already approximate by treating the cache
+ *  as "recently used".
+ */
+const MAX_RESOLVED_ENTRIES = 4096;
 const resolved = new Map<string, ShirabeWord | null>();
+
+function rememberResolved(key: string, value: ShirabeWord | null): void {
+  // `Map` keeps insertion order on iteration, so `delete + set` moves the key
+  // to the most-recent position without us tracking access timestamps. This
+  // matches the comment above: the cache is "asked recently", not "touched
+  // recently" -- a reader who has not asked a word for a while is exactly
+  // whose entry we want to evict.
+  if (resolved.has(key)) resolved.delete(key);
+  resolved.set(key, value);
+  while (resolved.size > MAX_RESOLVED_ENTRIES) {
+    const oldest = resolved.keys().next().value;
+    if (oldest === undefined) break;
+    resolved.delete(oldest);
+  }
+}
 
 /** The answer if it is already here, so a card can open filled in rather than
  *  flashing a loading state for a word the page has seen. `undefined` means it
@@ -67,11 +95,13 @@ export function fetchWord(wid: string, locale: string): Promise<ShirabeWord | nu
     timeout: 8000,
   })
     .then((word) => {
-      resolved.set(key, word);
+      rememberResolved(key, word);
       return word;
     })
     .catch(() => {
-      resolved.set(key, null);
+      // `null` (asked, no entry) goes through the same bounded store as a hit:
+      // the comment on `rememberResolved` covers why we want to remember it.
+      rememberResolved(key, null);
       return null;
     })
     .finally(() => {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -355,6 +355,17 @@ export default defineNuxtConfig({
     // everyone. `swr` keeps serving the stale copy while it refreshes, so a
     // reader never waits on a revalidation.
     '/api/shirabe/**': { swr: 60 * 60 * 24, headers: { 'Cache-Control': 'public, max-age=86400' } },
+    // Locale messages from nuxt-i18n's built-in `/_i18n/:hash/:locale/messages.json`
+    // route: identical for every reader and only change when a new build is
+    // rolled out (the `:hash` segment of the URL is the build id). Without this
+    // rule every browser fetches the JSON through Nitro on first paint, which
+    // takes the SSR process through JSON.parse + JSON.stringify on a hot path.
+    // On 2026-08-09 JST a traffic spike drove that endpoint to ~167k requests
+    // in three hours and pushed the SSR past its 512 MiB default `--max-old-space-size`
+    // (see issue #484). Cached at the origin like `/api/shirabe/**` above: one
+    // copy per build, served stale-while-revalidate so a reader never waits on
+    // a revalidation.
+    '/_i18n/**': { swr: 60 * 60 * 24, headers: { 'Cache-Control': 'public, max-age=86400' } },
     // Block all indexing on dev environments
     ...(isDev && {
       '/**': {


### PR DESCRIPTION
Draft PR — implements the fix proposed in #484. Three independent changes, each addressing a separate contributing cause for the JST-morning OOM crash loop.

## What this fixes

Yesterday's spike to ~28 req/s on `/_i18n/.../messages.json` (167k hits in three hours, 75% of SSR traffic) walked the SSR past its default 512 MiB `--max-old-space-size` and crash-looped with `FATAL ERROR: ... JavaScript heap out of memory`. Full data and queries are in #484.

## Changes

### 1. `frontend/nuxt.config.ts` — cache `/_i18n/**` at the origin

Same shape that already covers `/api/shirabe/**`: `swr: 86400` plus `Cache-Control: public, max-age=86400`. The `:hash` segment of the URL is the build id, so the JSON only changes per build; a day-long `swr` is the right change rate. Without this, every browser on first paint asks Nitro for the JSON, which is the path that used all the heap under load.

### 2. `frontend/Dockerfile` — set an explicit `--max-old-space-size`

`ENV NODE_OPTIONS=--max-old-space-size=1536`. 1536 MiB is the next multiple-of-512 above the 600+ MiB working-set we observed, with headroom for the OTel batch processor + Pino buffer under load. The Dockerfile is the layer that decides the runtime, so the change belongs here rather than at the call site.

### 3. `frontend/app/utils/wordLookup.ts` — bound the resolved map

The shared `Map<string, ShirabeWord | null>` is module-scoped, so it survives across renders on a long-lived SSR worker. Without a cap, every distinct `wid:locale` a reader asks about adds a key that never falls out. Cap at `MAX_RESOLVED_ENTRIES = 4096` with FIFO eviction (`delete + set` to mark recent — `Map` keeps insertion order on iteration, so the comment on `peekWord` about "recently used" is the eviction criterion without a per-access timestamp). The server route already serves `cache-control: max-age=86400` on `/api/shirabe/words/:wid`, so an evicted key costs a browser-cache hit at worst.

### Tests

Added `frontend/app/utils/__tests__/wordLookup.test.ts` covering cache hit/miss, in-flight coalescing, null-on-failure, per-locale isolation, and the eviction contract.

## What's still unknown

- Whether the Cloudflare Cache Rules are currently passing `/_i18n/**` through. The endpoint showed no `cf_ray` in the SSR logs, which doesn't tell us what CF did upstream. If CF is not caching the i18n files at the edge either, the swr rule moves the bottleneck but doesn't remove it — adding a CF Cache Rule for `/_i18n/848c6a34/**` would push it all the way to the edge. That's a `brigadasos-infra` change.
- Whether the spike was organic or one of the heavy browser sessions doing something pathological. A heap snapshot from the running prod container (via a `/admin/debug/heap` route gated by a service API key) would confirm the retaining set. With this patch, the heap should never reach that state again, but a snapshot would settle which object was growing.