### PR TITLE
Error reporting: stop filing the search and playback failures nobody can act on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,17 @@ jobs:
       - name: Bundle base OpenAPI specs
         run: |
           set -euo pipefail
-          # @redocly/cli is a devDependency of the backend workspace and the
-          # lockfile installs it at backend/node_modules/@redocly/cli -- it does
-          # NOT hoist to the checkout root. The previous path here assumed it
-          # did, so this step died with exit 127 the moment it ran. It only runs
-          # when a PR touches the spec, so it stayed hidden.
-          REDOCLY="${GITHUB_WORKSPACE}/head/backend/node_modules/.bin/redocly"
+          # @redocly/cli is a devDependency of the backend workspace, and npm
+          # DOES hoist it to the checkout root -- `node_modules/.bin/redocly`,
+          # with the package at `node_modules/@redocly/cli`. Nothing is installed
+          # under `backend/node_modules` at all.
+          #
+          # This is the second wrong guess at this path. The previous comment
+          # asserted the opposite, confidently, and the step went on failing with
+          # exit 127 -- because the job only runs when a PR touches the spec, so
+          # nothing exercised the "fix". Verified against an actual install this
+          # time rather than reasoned about: `ls node_modules/.bin/redocly`.
+          REDOCLY="${GITHUB_WORKSPACE}/head/node_modules/.bin/redocly"
           cd "${GITHUB_WORKSPACE}/base/backend"
           "$REDOCLY" bundle public -o docs/generated/openapi-public.yaml --remove-unused-components
           "$REDOCLY" bundle main -o docs/generated/openapi.yaml --remove-unused-components
@@ -105,7 +110,7 @@ jobs:
       - name: Bundle head OpenAPI specs
         run: |
           set -euo pipefail
-          REDOCLY="${GITHUB_WORKSPACE}/head/backend/node_modules/.bin/redocly"
+          REDOCLY="${GITHUB_WORKSPACE}/head/node_modules/.bin/redocly"
           cd "${GITHUB_WORKSPACE}/head/backend"
           "$REDOCLY" bundle public -o docs/generated/openapi-public.yaml --remove-unused-components
           "$REDOCLY" bundle main -o docs/generated/openapi.yaml --remove-unused-components

--- a/backend/app/services/search/segmentDocument/SegmentResponse.ts
+++ b/backend/app/services/search/segmentDocument/SegmentResponse.ts
@@ -404,4 +404,3 @@ export class SegmentResponse {
     return ALL_CATEGORIES.includes(value as CategoryType);
   }
 }
-

--- a/backend/tests/controllers/searchFilters.test.ts
+++ b/backend/tests/controllers/searchFilters.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { Media } from '@app/models';
-import { normalizeLanguageFilter, resolveMediaFilterIds, resolvePreferredMediaIds } from '@app/controllers/searchFilters';
+import {
+  normalizeLanguageFilter,
+  resolveMediaFilterIds,
+  resolvePreferredMediaIds,
+} from '@app/controllers/searchFilters';
 import { s_SearchFilters } from 'generated/schemas';
 import type { t_SearchFilters } from 'generated/models';
 

--- a/frontend/app/assets/css/tailwind.css
+++ b/frontend/app/assets/css/tailwind.css
@@ -65,7 +65,9 @@
     background: var(--control);
     color: var(--ink-faint);
     border: 1px solid var(--line);
-    transition: color 0.15s ease, background-color 0.15s ease;
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease;
   }
   .nd-btn:hover:not(:disabled) {
     background: var(--control-hover);
@@ -91,7 +93,10 @@
     background-repeat: no-repeat;
     background-position: right 0.75rem center;
     background-size: 1rem;
-    transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease,
+      border-color 0.15s ease;
   }
   select.nd-input:hover:not(:disabled),
   select.nd-select:hover:not(:disabled) {

--- a/frontend/app/components/media/modal/ModalMediaEdit.vue
+++ b/frontend/app/components/media/modal/ModalMediaEdit.vue
@@ -47,8 +47,7 @@ const seasonOptions = ['WINTER', 'SPRING', 'SUMMER', 'FALL', 'NONE'] as const;
 const pillClasses = (active: boolean) => {
   const base =
     'px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-neutral-900 cursor-pointer';
-  if (!active)
-    return `${base} border border-hairline text-ink-muted hover:border-line-hover hover:text-ink`;
+  if (!active) return `${base} border border-hairline text-ink-muted hover:border-line-hover hover:text-ink`;
   return `${base} bg-blue-600/80 text-blue-100 border border-blue-500 focus:ring-blue-500`;
 };
 

--- a/frontend/app/components/search/modal/segmentEdit/SegmentEditForm.vue
+++ b/frontend/app/components/search/modal/segmentEdit/SegmentEditForm.vue
@@ -49,8 +49,7 @@ const charCountColor = (len: number) => {
 const statusPillClasses = (value: string, active: boolean) => {
   const base =
     'px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-neutral-900 cursor-pointer';
-  if (!active)
-    return `${base} border border-hairline text-ink-muted hover:border-line-hover hover:text-ink`;
+  if (!active) return `${base} border border-hairline text-ink-muted hover:border-line-hover hover:text-ink`;
   const colors: Record<string, string> = {
     green: 'bg-green-600/80 text-green-100 border border-green-500 focus:ring-green-500',
     blue: 'bg-blue-600/80 text-blue-100 border border-blue-500 focus:ring-blue-500',

--- a/frontend/app/components/user/ActivityDashboard.vue
+++ b/frontend/app/components/user/ActivityDashboard.vue
@@ -27,11 +27,7 @@ function reportInitialFailure(slice: string) {
 // Declared above the initial load because that load now fetches the ranking too:
 // it is rendered on this page alone, and fetching it from `onMounted` meant the
 // transparency list arrived empty and then filled in a moment after hydration.
-const {
-  entries: familiarEntries,
-  load: loadFamiliarMedia,
-  forget: forgetFamiliar,
-} = useFamiliarMedia();
+const { entries: familiarEntries, load: loadFamiliarMedia, forget: forgetFamiliar } = useFamiliarMedia();
 
 const { data: initialData } = await useAsyncData(
   'settings-activity-initial',

--- a/frontend/app/composables/__tests__/useSearchFetch.test.ts
+++ b/frontend/app/composables/__tests__/useSearchFetch.test.ts
@@ -11,6 +11,9 @@ const sdkMocks = vi.hoisted(() => ({
 
 vi.mock('@brigadasos/nadeshiko-sdk', () => sdkMocks);
 
+const reportErrorMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/reportError', () => ({ reportError: reportErrorMock }));
+
 import { deferred } from './deferred';
 import {
   COLLECTION_PAGE_SIZE,
@@ -51,6 +54,7 @@ beforeEach(() => {
   for (const mock of Object.values(sdkMocks)) {
     mock.mockReset();
   }
+  reportErrorMock.mockReset();
 });
 
 describe('createRequestSequencer', () => {
@@ -293,6 +297,60 @@ describe('fetchSentences', () => {
     sdkMocks.search.mockResolvedValueOnce({ error: {}, response: new Response(null, { status: 401 }) });
     expect(await fetcher.fetchSentences(scope())).toEqual({ status: 'forbidden' });
   });
+
+  // A transport failure resolves with no `response` at all rather than throwing,
+  // so it lands on the same branch a 500 does. It stays out of PostHog's issue
+  // list -- nothing here is ours to fix -- but not out of Faro, which is the
+  // only place an edge outage would show while the origin looks healthy.
+  it('keeps a request that never got a response out of the issue list, not out of Faro', async () => {
+    const fetcher = createSearchFetcher(fakeSdk);
+
+    sdkMocks.search.mockResolvedValueOnce({ error: {}, response: undefined });
+    expect(await fetcher.fetchSentences(scope())).toEqual({ status: 'error' });
+    expect(reportErrorMock).toHaveBeenCalledWith(
+      'search:sentences-fetch-failed',
+      expect.any(Error),
+      expect.objectContaining({ 'http.status_code': '0' }),
+      { faroOnly: true },
+    );
+  });
+
+  it('drops a 429 outright, since the server already counts its own throttling', async () => {
+    const fetcher = createSearchFetcher(fakeSdk);
+
+    sdkMocks.search.mockResolvedValueOnce({ error: {}, response: new Response(null, { status: 429 }) });
+    expect(await fetcher.fetchSentences(scope())).toEqual({ status: 'error' });
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('still reports a fault the server owns', async () => {
+    const fetcher = createSearchFetcher(fakeSdk);
+
+    sdkMocks.search.mockResolvedValueOnce({ error: {}, response: new Response(null, { status: 502 }) });
+    expect(await fetcher.fetchSentences(scope())).toEqual({ status: 'error' });
+    expect(reportErrorMock).toHaveBeenCalledWith(
+      'search:sentences-fetch-failed',
+      expect.any(Error),
+      expect.objectContaining({ 'http.status_code': '502' }),
+      { faroOnly: false },
+    );
+  });
+
+  // The one case the issue was opened for that IS a bug: a 200 whose body did
+  // not parse into anything. Silencing this alongside the transport failures
+  // would leave nothing watching it.
+  it('still reports a 200 that carried no body', async () => {
+    const fetcher = createSearchFetcher(fakeSdk);
+
+    sdkMocks.search.mockResolvedValueOnce({ data: undefined, response: new Response(null, { status: 200 }) });
+    expect(await fetcher.fetchSentences(scope())).toEqual({ status: 'error' });
+    expect(reportErrorMock).toHaveBeenCalledWith(
+      'search:sentences-fetch-failed',
+      expect.any(Error),
+      expect.objectContaining({ 'http.status_code': '200' }),
+      { faroOnly: false },
+    );
+  });
 });
 
 describe('fetchStats', () => {
@@ -304,6 +362,21 @@ describe('fetchStats', () => {
 
     sdkMocks.getSearchStats.mockResolvedValueOnce({ error: {}, response: new Response(null, { status: 500 }) });
     expect(await fetcher.fetchStats(scope())).toEqual({ status: 'error' });
+  });
+
+  // The stats fetch fires alongside the sentences one, so a reader whose network
+  // drops files two reports for one event. Same rule, applied on both paths.
+  it('applies the same Faro-only rule to a stats request that never got a response', async () => {
+    const fetcher = createSearchFetcher(fakeSdk);
+
+    sdkMocks.getSearchStats.mockResolvedValueOnce({ error: {}, response: undefined });
+    expect(await fetcher.fetchStats(scope())).toEqual({ status: 'error' });
+    expect(reportErrorMock).toHaveBeenCalledWith(
+      'search:stats-fetch-failed',
+      expect.any(Error),
+      expect.objectContaining({ 'http.status_code': '0' }),
+      { faroOnly: true },
+    );
   });
 
   it('runs on its own sequence, independent of the result list', async () => {
@@ -355,9 +428,7 @@ describe('fetchSentences preferMedia', () => {
   it('sends it for an explicit RELEVANCE too, which means the same order', async () => {
     okOnce();
 
-    await createSearchFetcher(fakeSdk).fetchSentences(
-      scope({ sort: 'relevance', preferMedia: ['aaaaaaaaaaaa'] }),
-    );
+    await createSearchFetcher(fakeSdk).fetchSentences(scope({ sort: 'relevance', preferMedia: ['aaaaaaaaaaaa'] }));
 
     expect(bodyOf().preferMedia).toEqual(['aaaaaaaaaaaa']);
   });

--- a/frontend/app/composables/useSearchFetch.ts
+++ b/frontend/app/composables/useSearchFetch.ts
@@ -210,6 +210,16 @@ export const buildStatsFilters = (scope: SearchScope): SearchFilters =>
 const isForbidden = (response: Response | undefined): boolean => response?.status === 401 || response?.status === 403;
 
 /**
+ * The request never got an answer at all: the connection dropped, the tab was
+ * navigating away, an extension blocked it, the edge is down.
+ *
+ * It surfaces here rather than in the `catch` below because the SDK client
+ * resolves transport failures instead of throwing, so `response` is absent (or,
+ * for an opaque one, status 0) and there is no status to report.
+ */
+const isTransportFailure = (response: Response | undefined): boolean => response === undefined || response.status === 0;
+
+/**
  * A response that came back without a body. 401/403 is the server telling the
  * caller "not yours" -- expected, and reporting it only buys noise: Cloudflare
  * challenges and expired sessions both land here, from clients we cannot fix.
@@ -228,13 +238,39 @@ const emptyResponseOutcome = (
   if (isForbidden(response)) {
     return { status: 'forbidden' };
   }
+
+  // 429 is the server asking for less. Answered by backing off, not by a fix
+  // here, and the server already counts its own throttling -- so this one is
+  // dropped outright rather than reported anywhere.
+  if (response?.status === 429) {
+    return { status: 'error' };
+  }
+
+  // A transport failure goes to Faro but NOT to PostHog error tracking. Two
+  // thirds of both search fingerprints were this, landing on the sentences and
+  // the stats fetch in the *same millisecond* -- one reader's network going
+  // away, filed as two faults of ours. As triaged issues they are unactionable
+  // noise, which is what buried the reports that are not.
+  //
+  // They are still worth counting, though, and dropping them entirely was the
+  // wrong trade: if the edge fails while the origin is healthy, server-side
+  // metrics look fine and this is the only place the outage is visible. Faro
+  // takes it as one more exception in a stream nobody triages, where a spike
+  // reads as a spike; PostHog keeps its issue list about things with a fix.
+  const transportFailure = isTransportFailure(response);
+
   // The status code stays OUT of the message and in the properties: it is the one
   // part that varies, and interpolating it would fingerprint 500 apart from 503
   // and scatter one fault across an issue per status code.
-  reportError(`search:${kind}-fetch-failed`, new Error(`search ${kind} fetch returned an empty response`), {
-    'search.scope': scope,
-    'http.status_code': String(response?.status ?? 0),
-  });
+  reportError(
+    `search:${kind}-fetch-failed`,
+    new Error(`search ${kind} fetch returned an empty response`),
+    {
+      'search.scope': scope,
+      'http.status_code': String(response?.status ?? 0),
+    },
+    { faroOnly: transportFailure },
+  );
   return { status: 'error' };
 };
 

--- a/frontend/app/stores/player.test.ts
+++ b/frontend/app/stores/player.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { SearchResult } from '~/types/search';
-import { resolveAudioSource } from './player';
+import { isUnactionablePlaybackError, resolveAudioSource } from './player';
 
 const result = (blobAudioUrl: string | null): SearchResult =>
   ({
@@ -32,5 +32,41 @@ describe('resolveAudioSource', () => {
 
     expanded.blobAudioUrl = null;
     expect(resolveAudioSource(expanded)).toBe('https://cdn.test/seg-1.mp3');
+  });
+});
+
+describe('isUnactionablePlaybackError', () => {
+  // The exact rejections production sees, verbatim, so a rename upstream shows
+  // up here rather than as a fingerprint quietly filling back up.
+  it('drops the aborts the reader causes', () => {
+    expect(
+      isUnactionablePlaybackError(
+        new DOMException(
+          'The play() request was interrupted because the media was removed from the document.',
+          'AbortError',
+        ),
+      ),
+    ).toBe(true);
+    expect(isUnactionablePlaybackError(new DOMException('The operation was aborted.', 'AbortError'))).toBe(true);
+  });
+
+  it('drops the autoplay policy', () => {
+    expect(
+      isUnactionablePlaybackError(
+        new DOMException('play() can only be initiated by a user gesture.', 'NotAllowedError'),
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps a clip that will not decode', () => {
+    // The one this fingerprint exists for: the source is there and the browser
+    // refuses it. Filtering this would leave the issue reporting nothing.
+    expect(
+      isUnactionablePlaybackError(
+        new DOMException('The media resource indicated by the src attribute was not suitable.', 'NotSupportedError'),
+      ),
+    ).toBe(false);
+    expect(isUnactionablePlaybackError(new TypeError('Failed to fetch'))).toBe(false);
+    expect(isUnactionablePlaybackError('AbortError')).toBe(false);
   });
 });

--- a/frontend/app/stores/player.ts
+++ b/frontend/app/stores/player.ts
@@ -21,6 +21,30 @@ export function resolveAudioSource(result: SearchResult): string {
 }
 
 /**
+ * Rejections of `HTMLAudioElement.play()` that describe the reader rather than a
+ * fault, and so are dropped instead of reported.
+ *
+ * - `AbortError`: the user agent abandoned the load "at the user's request" --
+ *   navigating away, closing the tab, stopping playback mid-load.
+ * - `NotAllowedError`: the autoplay policy. This play() was not close enough to
+ *   a gesture for the reader's settings; they press play again and it works.
+ *
+ * Filtered here rather than tolerated in PostHog, because an issue nobody acts
+ * on is worse than no issue: its status and last-seen stop describing anything,
+ * and the `NotSupportedError` cases underneath -- a clip that genuinely will not
+ * decode, which IS worth knowing about -- get read as more of the same. Between
+ * them these two were 234 of the 255 reports on this fingerprint over a week,
+ * out of 9 sessions; the 21 that matter came from 14. The same confusion
+ * `$exception_fingerprint` was added to `reportError` to end.
+ */
+export function isUnactionablePlaybackError(error: unknown): boolean {
+  // Matched on `name` against any Error rather than on `instanceof DOMException`:
+  // the name is the part the spec pins down, and narrowing to the class buys
+  // nothing here -- nothing else rejects a play() with either of these names.
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'NotAllowedError');
+}
+
+/**
  * Identifies the most recent playback intent. `HTMLAudioElement.play()` settles
  * asynchronously, so a promise from a track the user already skipped past would
  * otherwise flip `isPlaying` and fire analytics for whatever is playing *now* —
@@ -164,26 +188,19 @@ export const usePlayerStore = defineStore('player', {
           if (token !== playbackToken) return;
           this.isPlaying = false;
 
-          // `AbortError` is the reader, not a fault. The spec raises it when the
-          // user agent abandons the fetch "at the user's request" -- navigating
-          // away, closing the tab, stopping playback mid-load -- so there is
-          // nothing to fix and nobody to tell.
-          //
-          // Filtered here rather than tolerated in PostHog, because an issue
-          // nobody acts on is worse than no issue: its status and last-seen stop
-          // describing anything, and the `NotSupportedError` cases underneath --
-          // a clip that genuinely will not play, which IS worth knowing about --
-          // get read as more of the same. The same confusion `$exception_fingerprint`
-          // was added to `reportError` to end.
-          //
           // Note this is not the teardown case: `releaseIfSource`, `hidePlayer`
           // and every `playCurrent` branch bump `playbackToken` before releasing,
           // so a play() we cancelled ourselves is already discarded by the guard
           // above and never reaches here.
-          if (error instanceof DOMException && error.name === 'AbortError') return;
+          if (isUnactionablePlaybackError(error)) return;
 
+          // What survives is a clip that genuinely would not decode. The source
+          // goes on the report because the segment id alone does not say which
+          // url was tried: an expansion plays a blob built in the browser, and
+          // it fails for reasons a CDN object never would.
           reportError('player:audio-play-failed', error, {
             'segment.publicId': this.currentResult?.segment.publicId ?? '',
+            'audio.source': audio.src,
           });
         });
     },

--- a/frontend/server/utils/ssrAuthCache.ts
+++ b/frontend/server/utils/ssrAuthCache.ts
@@ -75,7 +75,14 @@ const STORE_KEY = Symbol.for('nadeshiko.ssrAuthCache.store');
 type GlobalWithStore = typeof globalThis & { [STORE_KEY]?: Map<string, Entry<unknown>> };
 
 const globalWithStore = globalThis as GlobalWithStore;
-const store: Map<string, Entry<unknown>> = (globalWithStore[STORE_KEY] ??= new Map<string, Entry<unknown>>());
+// Split off the `??=` rather than assigning inside the initializer: biome's
+// noAssignInExpressions is an error here, and the two-step form says the same
+// thing -- reuse the store this process already parked on the global, or park
+// one now.
+if (!globalWithStore[STORE_KEY]) {
+  globalWithStore[STORE_KEY] = new Map<string, Entry<unknown>>();
+}
+const store: Map<string, Entry<unknown>> = globalWithStore[STORE_KEY];
 
 function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex').slice(0, 32);


### PR DESCRIPTION
Closes #503, closes #504, closes #505.

Three error-tracking issues that turned out to be one problem: each fingerprint was dominated by failures with no fix on our side, which buried the ones that have a fix.

The numbers here are from PostHog over the 7 days to 2026-08-16, not from the issue bodies — the issues were written from occurrence counts and time ranges, and the message and status-code breakdowns tell a different story.

### #503 — `player:audio-play-failed`

| Rejection | Occurrences | Sessions |
| --- | ---: | ---: |
| `AbortError` | 222 | 7 |
| `NotSupportedError` | 21 | 14 |
| `NotAllowedError` | 12 | 2 |

The issue reads this as a codec regression introduced by 2.3.5. It is mostly not that: 87% of it is `AbortError`, from 7 sessions, and **that is already fixed on `main`** — `ce1cfe264` ("drop the aborts readers cause") filters it and is one of the 35 commits sitting between the deployed `453bec7b` and `main`. It has never been in production, which is why the fingerprint kept filling up.

What this PR adds is `NotAllowedError` — the browser's autoplay policy. It means the `play()` was not close enough to a gesture for that reader's settings; they press play again and it works. 12 reports from **2 sessions**, so one reader with autoplay blocked can outweigh the thing the fingerprint exists for.

`NotSupportedError` is that thing, and it stays reported: 21 occurrences spread over 14 distinct sessions, which is a long tail of clips that genuinely will not decode rather than one broken reader. The report now carries `audio.source` too, because a segment id does not say whether a CDN object or a browser-built expansion blob was tried, and those fail for different reasons.

The predicate moves out of the catch block into an exported `isUnactionablePlaybackError` so it can be tested against the exact strings production sends.

### #504 / #505 — `search:sentences-fetch-failed`, `search:stats-fetch-failed`

Every event on both fingerprints comes from one branch (`emptyResponseOutcome`), so the status code is recorded on each. Grouped:

| `http.status_code` | sentences | stats |
| --- | ---: | ---: |
| `0` | 14 | 15 |
| `200` | 4 | 1 |
| `429` | 2 | 2 |
| `400` | 2 | — |
| `520` / `522` | 2 | 1 |

Two thirds is status `0` — no response at all. The SDK client resolves transport failures instead of throwing, so a dropped connection, a closing tab or a blocking extension lands on the same branch a 500 does. The giveaway is in the timestamps: the sentences and the stats fetch fail in the **same millisecond** (`10:45:38.004` / `.015`, `17:45:48.134` / `.138`). That is one reader's network going away, filed as two faults of ours. 429 joins it — answered by backing off, not by a change here.

The page still shows its error state for both. The 429s are dropped outright — the server already counts its own throttling. The transport failures go to Faro but not to PostHog error tracking, which is the split that matters: as triaged issues they are unactionable noise, and dropping them entirely would have been the wrong trade, because if the edge fails while the origin is healthy this is the only place the outage is visible at all. Faro takes them as exceptions in a stream nobody triages, where a spike reads as a spike; PostHog keeps its issue list about things with a fix.

What survives is worth keeping: the `200`s are the case #505 was actually opened for — a response that parsed to nothing — and 502/520/522 are ours to answer for. #505's premise that this correlates with the ~15% of `/v1/search/stats` calls returning `responseTime=1` does not hold, though: that is ~2,400 requests a day against 5 error events.

### Also here

A `Chore:` commit fixing three CI breakages `main` is carrying. Branches inherit all of them, because checks run against the merge with `main`.

- `biome check` fails in both workspaces: 6 unformatted files (2 backend, 4 frontend) plus one lint error, `noAssignInExpressions` in `ssrAuthCache.ts`. This is what took #507's checks red.
- The `openapi` job dies at its first step with exit 127, looking for `redocly` under `head/backend/node_modules`. npm hoists it to the checkout root. The comment on that line asserts the opposite, so this is the second wrong guess at the path — both survived because the job only runs when a PR touches the spec, and nothing had since. I checked it against a real install rather than reasoning about it. #509 is the PR that surfaced it.

Formatting, one `??=` split out of an initializer, and a path. No behaviour change.
