### PR TITLE
E2E: fix the six search and media failures blocking the staging release

### DIFF
--- a/frontend/app/pages/media/index.vue
+++ b/frontend/app/pages/media/index.vue
@@ -306,7 +306,12 @@ watch([searchQuery, filterCategory], () => {
       <div class="flex items-center mb-4">
         <SearchDropdownContainer class="" dropdownId="nd-dropdown-with-header">
           <template #default>
-            <SearchDropdownMainButton dropdownId="nd-dropdown-with-header">
+            <!-- Named rather than left on the shared `dropdown-toggle` test id.
+                 The page object reached for `.first()` of that id, which is a
+                 position on the page and not this control: once the header
+                 gained its own dropdown, `.first()` started resolving to the
+                 language switcher and the category assertion read " English". -->
+            <SearchDropdownMainButton dropdownId="nd-dropdown-with-header" testId="media-category-dropdown">
               {{ filterCategoryLabel }}
             </SearchDropdownMainButton>
           </template>

--- a/frontend/e2e/pages/MediaPage.ts
+++ b/frontend/e2e/pages/MediaPage.ts
@@ -16,7 +16,7 @@ export class MediaPage {
     this.page = page;
     this.mediaCards = page.getByTestId('media-card');
     this.searchInput = page.getByTestId('media-search-input');
-    this.categoryDropdown = page.getByTestId('dropdown-toggle').first();
+    this.categoryDropdown = page.getByTestId('media-category-dropdown');
     this.gridViewButton = page.getByTestId('grid-view-button');
     this.listViewButton = page.getByTestId('list-view-button');
     this.listItems = page.getByTestId('media-list-item');

--- a/frontend/e2e/pages/SearchPage.ts
+++ b/frontend/e2e/pages/SearchPage.ts
@@ -156,19 +156,46 @@ export class SearchPage {
    * dictionary knows opens a card at all: particles and names in a given
    * sentence are tokens with no entry behind them, and which ones those are
    * depends on the sentence the search happens to return.
+   *
+   * `excluding` skips a headword the caller cannot use — in practice the word
+   * the page is already searching for. Every result on `/search/彼女` contains
+   * 彼女, so it is routinely the first token with an entry, and searching it
+   * navigates to the URL the test is standing on. The callers that wait for the
+   * URL to *change* then wait forever, for a reason that has nothing to do with
+   * what they are testing.
    */
-  async openFirstTokenCard(): Promise<string> {
+  async openFirstTokenCard(options: { excluding?: string } = {}): Promise<string> {
     const tokens = this.page.locator('.token-text .token[role="button"]');
     await expect(tokens.first()).toBeVisible({ timeout: 15_000 });
 
     for (let i = 0; i < (await tokens.count()); i++) {
       await tokens.nth(i).click();
       if (await this.tokenCardSearch.isVisible({ timeout: 2_500 }).catch(() => false)) {
-        return (await this.tokenCardSearch.innerText()).trim();
+        const headword = await this.tokenCardHeadword();
+        if (headword !== options.excluding) return headword;
       }
       await this.page.keyboard.press('Escape');
     }
 
-    throw new Error('no token in the results opened a word card');
+    throw new Error('no token in the results opened a usable word card');
+  }
+
+  /**
+   * The headword as a word, with its reading stripped out.
+   *
+   * NOT `innerText()`. The card renders furigana as `<ruby>語<rt>ご</rt></ruby>`,
+   * and text extraction concatenates both halves — so the headword of 林間学校
+   * came back as "林間学校りんかんがっこう", which is not what pressing it
+   * searches for and matches nothing in the URL afterwards. `<rt>` holds the
+   * pronunciation guide by definition, so dropping it is what "the word" means
+   * whether or not a given entry happens to have furigana.
+   */
+  private async tokenCardHeadword(): Promise<string> {
+    const text = await this.tokenCardSearch.evaluate((element) => {
+      const clone = element.cloneNode(true) as HTMLElement;
+      for (const rt of clone.querySelectorAll('rt')) rt.remove();
+      return clone.textContent ?? '';
+    });
+    return text.trim();
   }
 }

--- a/frontend/e2e/specs/search/dropdown-menus.spec.ts
+++ b/frontend/e2e/specs/search/dropdown-menus.spec.ts
@@ -68,8 +68,12 @@ test.describe('Dropdown menus', () => {
     await expect(menu.getByText('Image', { exact: true })).toBeVisible();
     await expect(menu.getByText('Audio', { exact: true })).toBeVisible();
     await expect(menu.getByText('Japanese sentence', { exact: true })).toBeVisible();
+    // English only, and not because the menu lost Spanish: the copy menu offers
+    // a row per translation the card actually has, and a signed-out reader in
+    // the English locale is served English alone (`defaultTranslationLanguages`).
+    // The 'Spanish sentence' row this used to assert needs a reader who has
+    // chosen both languages globally -- see segment-card.spec.ts.
     await expect(menu.getByText('English sentence')).toBeVisible();
-    await expect(menu.getByText('Spanish sentence')).toBeVisible();
   });
 
   test('More dropdown opens and shows expand options', async () => {

--- a/frontend/e2e/specs/search/search-bar-query.spec.ts
+++ b/frontend/e2e/specs/search/search-bar-query.spec.ts
@@ -23,7 +23,9 @@ test.describe('The search bar shows the search in the URL', () => {
     await search.goto('彼女');
     await search.expectResultsVisible();
 
-    const word = await search.openFirstTokenCard();
+    // Excluding the word the page is already on: searching it would navigate to
+    // the URL we are standing on, and the wait below is for the URL to change.
+    const word = await search.openFirstTokenCard({ excluding: '彼女' });
     await search.tokenCardSearch.click();
     await page.waitForURL((url) => !url.pathname.endsWith(encodeURIComponent('彼女')), { timeout: 15_000 });
 

--- a/frontend/e2e/specs/search/segment-card.spec.ts
+++ b/frontend/e2e/specs/search/segment-card.spec.ts
@@ -16,10 +16,21 @@ test.describe('Segment card', () => {
     await expect(japaneseText).not.toBeEmpty();
   });
 
-  test('displays EN and ES translations', async ({ page }) => {
+  /**
+   * The interface language decides which translations are asked for, until a
+   * reader saves a global override -- `defaultTranslationLanguages`, whose own
+   * unit test spells out `'en' -> ['EN']`. This suite runs signed out in the
+   * English locale, so English is the whole of what a card should carry here.
+   *
+   * This used to assert EN *and* ES, from when search fetched both regardless.
+   * It is not asserting the absence of Spanish either: that would pin a product
+   * default into a test whose subject is the card. Covering the two-language
+   * rendering needs a reader who has chosen both, which is a signed-in spec and
+   * does not exist yet.
+   */
+  test('displays the translation for the interface language', async ({ page }) => {
     const card = search.segmentCards.first();
     await expect(card.getByTestId('translation-badge-EN')).toBeVisible();
-    await expect(card.getByTestId('translation-badge-ES')).toBeVisible();
   });
 
   test('displays media name and episode info', async ({ page }) => {

--- a/frontend/e2e/specs/search/token-search.spec.ts
+++ b/frontend/e2e/specs/search/token-search.spec.ts
@@ -23,7 +23,7 @@ test.describe('Searching a word from a sentence', () => {
     const mediaId = new URL(page.url()).searchParams.get('media');
     await search.expectResultsVisible();
 
-    const headword = await search.openFirstTokenCard();
+    const headword = await search.openFirstTokenCard({ excluding: QUERY });
     await search.tokenCardSearch.click();
 
     await expect.poll(() => search.searchedWord(), { timeout: 10_000 }).toBe(headword);
@@ -40,7 +40,7 @@ test.describe('Searching a word from a sentence', () => {
     await search.goto(QUERY);
     await search.expectResultsVisible();
 
-    const headword = await search.openFirstTokenCard();
+    const headword = await search.openFirstTokenCard({ excluding: QUERY });
     await search.tokenCardSearch.click();
 
     await expect.poll(() => search.searchedWord(), { timeout: 10_000 }).toBe(headword);
@@ -60,8 +60,9 @@ test.describe('Searching a word from a sentence', () => {
     // Clicked first, so the word compared against is the one the card actually
     // searched for. Waiting on "the URL moved" rather than on the word itself:
     // a headword equal to the query the page is already on would satisfy that
-    // check before the click had gone anywhere.
-    const headword = await search.openFirstTokenCard();
+    // check before the click had gone anywhere -- which `excluding` now rules
+    // out at the source, for every caller rather than just this one.
+    const headword = await search.openFirstTokenCard({ excluding: QUERY });
     await search.tokenCardSearch.click();
     await page.waitForURL((url) => url.toString() !== scopedUrl, { timeout: 10_000 });
     expect(search.searchedWord()).toBe(headword);


### PR DESCRIPTION
The `[Stg] Release` workflow has been failing since 2026-08-14 — six E2E failures, all of them predating this branch. They are why 2.4.0 has not reached staging.

The suite runs against deployed staging, after the deploy, so this cannot be verified locally; the loop is the staging run itself. All 241 specs parse (`playwright test --list`) and the changed files typecheck.

To be clear about what changed and what did not: **five of the six are the tests being wrong, one is the app**. No product behaviour changes here.

## Translations — `segment-card.spec.ts`, `dropdown-menus.spec.ts`

`87619065` ("Search: pick translation visibility from a three-item menu") rewired `includedLanguages` to derive from the reader's global language choice rather than from the per-language hidden flags. `defaultTranslationLanguages` maps the interface language until the reader saves an override, and the commit's own unit test states it:

```
expect(defaultTranslationLanguages('en')).toEqual(['EN']);
```

Both specs run **signed out in the English locale**, so English is now the whole of what a card carries. They were asserting EN *and* ES, which was the default before that commit.

I did not replace those with an assertion that Spanish is *absent* — that would pin a product default into a test whose subject is the card and the copy menu. The two-language rendering path is still real and still worth covering; it needs a reader who has chosen both languages globally, which is a signed-in spec and does not exist yet. Worth adding separately.

Flagging the behaviour itself, since it is a user-visible change that the commit title does not advertise: **an English-locale reader with no saved override now gets English-only translations in search, where they previously got both.** The author's unit test says that is intended, so I have treated it as intended.

## The media category dropdown — `media.spec.ts`

```
Expected substring: "Anime"
Received string:    " English"
```

`MediaPage.categoryDropdown` was `getByTestId('dropdown-toggle').first()` — a *position on the page*, not a control. Once the header gained a dropdown of its own, `.first()` started resolving to the language switcher (`id="nd-dropdown-language-v-0-1"` in the failure log).

This is the one app-side change: the media page's dropdown now passes `testId="media-category-dropdown"` (a prop `DropdownMainButton` already supports), and the page object asks for it by name.

## The word card headword — `token-search.spec.ts` ×2

```
Expected: "林間学校りんかんがっこう"
Received: "林間学校"
```

The headword renders furigana as `<ruby>語<rt>ご</rt></ruby>`, and `innerText()` concatenates both halves. So the helper returned the word glued to its own reading — not what pressing it searches for, and matching nothing in the URL afterwards. `<rt>` holds the pronunciation guide by definition, so stripping it is what "the word" means, furigana or not.

## The word card headword — `search-bar-query.spec.ts`

`page.waitForURL` timed out waiting for the path to stop ending in 彼女. Every result on `/search/彼女` contains 彼女, so it is routinely the first token with a dictionary entry — and searching it navigates to the URL the test is already standing on, so the wait never resolves.

`openFirstTokenCard({ excluding })` skips a headword the caller cannot use. One of the token-search specs already carried a comment about exactly this hazard and worked around it locally by waiting on "the URL moved" instead; this fixes it at the source, for every caller, and removes a whole class of corpus-dependent flake. Applied to all four navigation-dependent callers.

## Not addressed

`search-bar-query.spec.ts:34` ("going back restores the search that URL was for") was reported **flaky** rather than failed — it passed on retry. I have left it alone rather than change a test on one observation of a timing-sensitive `goBack`.
