### PR TITLE
E2E: wait on the URL, not on a YouTube iframe, and give ES a reader who has it

### DIFF
--- a/frontend/e2e/pages/SearchPage.ts
+++ b/frontend/e2e/pages/SearchPage.ts
@@ -65,19 +65,46 @@ export class SearchPage {
     return match?.[1] ?? null;
   }
 
-  async goto(query?: string) {
+  /**
+   * `locale` prefixes the path, which the app routes on (`strategy: 'prefix'`).
+   *
+   * It is how a spec asks for a reader with two translation languages without
+   * signing in: the interface language picks the default set until a reader
+   * saves an override, and only `ja` defaults to both EN and ES — `en` gets
+   * English alone, `es` Spanish alone. See `defaultTranslationLanguages`.
+   */
+  async goto(query?: string, options: { locale?: 'en' | 'es' | 'ja' } = {}) {
+    const prefix = options.locale ? `/${options.locale}` : '';
     if (query) {
-      await this.page.goto(`/search/${encodeURIComponent(query)}`);
+      await this.page.goto(`${prefix}/search/${encodeURIComponent(query)}`);
     } else {
-      await this.page.goto('/search');
+      await this.page.goto(`${prefix}/search`);
     }
   }
 
+  /**
+   * Runs a search from the bar and waits for the URL to be the one asked for.
+   *
+   * Two things this used to get wrong, both of which showed up as a later step
+   * timing out somewhere unrelated:
+   *
+   * `/\/search\//` matched the URL the page was ALREADY on, so this could
+   * return before the navigation had happened at all — leaving the caller to
+   * act on the previous search, and any history assertion after it reading a
+   * stack that had not moved yet.
+   *
+   * `waitUntil: 'commit'` because the default is `'load'`: a results page whose
+   * first card is a YouTube segment embeds a `youtube-nocookie.com` iframe, and
+   * the page load state need never arrive. The URL is what this is waiting for.
+   */
   async search(query: string) {
     await this.searchInput.clear();
     await this.searchInput.fill(query);
     await this.searchButton.click();
-    await this.page.waitForURL(/\/search\//, { timeout: 10_000 });
+    await this.page.waitForURL((url) => url.pathname.endsWith(`/search/${encodeURIComponent(query)}`), {
+      timeout: 10_000,
+      waitUntil: 'commit',
+    });
   }
 
   /**

--- a/frontend/e2e/specs/search/recent-searches.spec.ts
+++ b/frontend/e2e/specs/search/recent-searches.spec.ts
@@ -92,7 +92,7 @@ test.describe('Recent searches', () => {
 
     await search.recentsMenu.getByTestId('search-recents-media').locator('..').click();
 
-    await page.waitForURL(new RegExp(`media=${mediaId}`), { timeout: 10_000 });
+    await page.waitForURL(new RegExp(`media=${mediaId}`), { timeout: 10_000, waitUntil: 'commit' });
     await expect(search.searchInput).toHaveValue('学校');
   });
 
@@ -111,7 +111,7 @@ test.describe('Recent searches', () => {
 
     // The seeded row carries no title, so re-running it must drop the `media`
     // filter the page was wearing rather than inherit it.
-    await page.waitForURL(/\/search\/%E7%8C%AB/, { timeout: 10_000 });
+    await page.waitForURL(/\/search\/%E7%8C%AB/, { timeout: 10_000, waitUntil: 'commit' });
     expect(new URL(page.url()).searchParams.get('media')).toBeNull();
   });
 
@@ -164,7 +164,7 @@ test.describe('Recent searches', () => {
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
 
-    await page.waitForURL(/\/search\/%E5%AD%A6%E6%A0%A1/, { timeout: 10_000 });
+    await page.waitForURL(/\/search\/%E5%AD%A6%E6%A0%A1/, { timeout: 10_000, waitUntil: 'commit' });
     await expect(search.searchInput).toHaveValue('学校');
   });
 
@@ -176,7 +176,7 @@ test.describe('Recent searches', () => {
 
     await search.recentsItem('学校').first().click();
 
-    await page.waitForURL(/\/search\/%E5%AD%A6%E6%A0%A1/, { timeout: 10_000 });
+    await page.waitForURL(/\/search\/%E5%AD%A6%E6%A0%A1/, { timeout: 10_000, waitUntil: 'commit' });
     await expect(search.searchInput).toHaveValue('学校');
   });
 

--- a/frontend/e2e/specs/search/search-bar-query.spec.ts
+++ b/frontend/e2e/specs/search/search-bar-query.spec.ts
@@ -27,7 +27,10 @@ test.describe('The search bar shows the search in the URL', () => {
     // the URL we are standing on, and the wait below is for the URL to change.
     const word = await search.openFirstTokenCard({ excluding: '彼女' });
     await search.tokenCardSearch.click();
-    await page.waitForURL((url) => !url.pathname.endsWith(encodeURIComponent('彼女')), { timeout: 15_000 });
+    await page.waitForURL((url) => !url.pathname.endsWith(encodeURIComponent('彼女')), {
+      timeout: 15_000,
+      waitUntil: 'commit',
+    });
 
     expect(await search.searchInput.inputValue()).toBe(word);
     expect(word).toBe(decodeURIComponent(new URL(page.url()).pathname.split('/search/')[1] ?? ''));
@@ -43,7 +46,7 @@ test.describe('The search bar shows the search in the URL', () => {
     await expect(search.searchInput).toHaveValue('猫');
 
     await page.goBack();
-    await page.waitForURL(/\/search\/%E5%AD%A6%E6%A0%A1$/, { timeout: 15_000 });
+    await page.waitForURL(/\/search\/%E5%AD%A6%E6%A0%A1$/, { timeout: 15_000, waitUntil: 'commit' });
     await expect(search.searchInput).toHaveValue('学校');
   });
 

--- a/frontend/e2e/specs/search/token-search.spec.ts
+++ b/frontend/e2e/specs/search/token-search.spec.ts
@@ -64,7 +64,7 @@ test.describe('Searching a word from a sentence', () => {
     // out at the source, for every caller rather than just this one.
     const headword = await search.openFirstTokenCard({ excluding: QUERY });
     await search.tokenCardSearch.click();
-    await page.waitForURL((url) => url.toString() !== scopedUrl, { timeout: 10_000 });
+    await page.waitForURL((url) => url.toString() !== scopedUrl, { timeout: 10_000, waitUntil: 'commit' });
     expect(search.searchedWord()).toBe(headword);
     const clickedUrl = new URL(page.url());
 
@@ -80,7 +80,7 @@ test.describe('Searching a word from a sentence', () => {
     await expect(search.searchInput).toHaveValue(headword);
     await search.searchButton.click();
     if (headword !== QUERY) {
-      await page.waitForURL((url) => url.toString() !== scopedUrl, { timeout: 10_000 });
+      await page.waitForURL((url) => url.toString() !== scopedUrl, { timeout: 10_000, waitUntil: 'commit' });
     }
     const typedUrl = new URL(page.url());
 

--- a/frontend/e2e/specs/search/translation-visibility.spec.ts
+++ b/frontend/e2e/specs/search/translation-visibility.spec.ts
@@ -1,12 +1,27 @@
 import { test, expect } from '../../fixtures';
 import { SearchPage } from '../../pages/SearchPage';
 
+/**
+ * Driven from the Japanese locale, and that is load-bearing rather than
+ * incidental.
+ *
+ * This feature is per-language: half of it is that the EN and ES menus move
+ * independently. Since `87619065` a reader is only offered the languages their
+ * interface language defaults them to — English alone in `en`, Spanish alone in
+ * `es` — so run signed out in `en` there is no ES control to open and no ES
+ * badge to assert, and five of these tests were asserting a two-language page
+ * that reader never sees.
+ *
+ * `ja` is the locale that defaults to both (`defaultTranslationLanguages`), so
+ * it is the one that exercises the whole feature without an account. Every
+ * locator here is a test id, so the Japanese interface changes nothing else.
+ */
 test.describe('Translation visibility', () => {
   let search: SearchPage;
 
   test.beforeEach(async ({ page }) => {
     search = new SearchPage(page);
-    await search.goto('彼女');
+    await search.goto('彼女', { locale: 'ja' });
     await search.expectResultsVisible();
   });
 


### PR DESCRIPTION
Second round, from the staging run after #510. Those six are fixed — 125 passing where it was 114 — and getting further surfaced two more causes that the earlier bail had hidden (`108 did not run`, down from `119`).

## `waitForURL` was waiting for the wrong thing

This one is worth reading the evidence for, because it explains a test that has been dismissed as flaky.

`page.waitForURL` defaults to `waitUntil: 'load'` — it waits for the URL to match **and** for the page to reach the load state. I pulled the trace for `going back restores the search that URL was for` and dumped the frame URLs in order:

```
https://stg.nadeshiko.co/en/search/%E5%AD%A6%E6%A0%A1
https://www.youtube-nocookie.com/embed/OYLe3TnXmA8?…
https://stg.nadeshiko.co/en/search/%E7%8C%AB
https://www.youtube-nocookie.com/embed/OYLe3TnXmA8?…
https://stg.nadeshiko.co/en/search/%E5%AD%A6%E6%A0%A1   ← goBack landed exactly right
```

The navigation worked. The URL was the one asserted. The wait then sat there for fifteen seconds and timed out on a load state that a `youtube-nocookie.com` iframe owns.

That also explains the flakiness: it depends on whether the first result on that page happens to be a YouTube segment, which the corpus decides. `search-bar-query.spec.ts:34` was reported *flaky* in one run and *failed* in the next, on identical code.

Switched the affected waits to `waitUntil: 'commit'`. The URL is what these assertions are about; everything after them auto-waits for content. Applied across `search-bar-query`, `token-search` and `recent-searches` — same hazard, same intent.

While there: `SearchPage.search()` waited on `/\/search\//`, which matches the URL the page is **already** standing on, so it could return before navigating anywhere and leave the caller acting on the previous search. It now waits for the query it was actually given.

## `translation-visibility` needs a reader who has ES

Five failures here, same root cause as the two in #510: since `87619065` a signed-out reader is offered only the languages their interface language defaults them to, and `en` is English alone. So there is no ES control to open and no ES badge to assert — and five of these tests are specifically about the ES half of a per-language feature, including `EN and ES menus are independent`, which has no meaning with one language.

Rather than delete that coverage, the file now runs in **`ja`** — the one locale whose default is both EN and ES (`defaultTranslationLanguages`), so it exercises the whole feature without needing an account. Every locator in the file is a test id, so the Japanese interface changes nothing else. `SearchPage.goto` takes an optional `locale` for this.

This is the better answer to the same question #510 handled by narrowing the assertion, and it is worth noting the asymmetry: `dropdown-menus` asserts English *UI strings* ('English sentence'), so that one has to stay in `en` and narrow instead.

## Still standing

The behaviour question from #509/#510 is unchanged and still yours to confirm: **an English-locale reader with no saved override now gets English-only translations in search.** Everything I have done treats that as intended, on the strength of the unit test `87619065` shipped with it. If it is not, these two PRs are the wrong fix and the change belongs in `useTranslationVisibility`.
