### PR TITLE
E2E: five more, from the parts of the suite that now get reached

### DIFF
--- a/frontend/e2e/specs/activity-privacy.spec.ts
+++ b/frontend/e2e/specs/activity-privacy.spec.ts
@@ -204,10 +204,16 @@ test.describe('Activity privacy', () => {
     await activity.expectLoaded();
     await expect(page.getByTestId('familiar-media-list')).toBeVisible({ timeout: 10_000 });
 
+    // Per title, not the one bulk button this used to press. `ac04d42ed`
+    // replaced "Forget which shows I study" with a Forget on each row, and this
+    // test kept reaching for `familiar-media-clear`, which has not existed
+    // since. The tally here is one title, so forgetting it empties the list --
+    // which is what this test is named for either way.
+    //
     // The button confirms first, and an unhandled dialog auto-dismisses -- which
     // would leave this test asserting that nothing happened.
     page.once('dialog', (dialog) => dialog.accept());
-    await page.getByTestId('familiar-media-clear').click();
+    await page.getByTestId(`familiar-media-forget-${mediaPublicId}`).click();
 
     await expect(page.getByTestId('familiar-media-list')).toHaveCount(0, { timeout: 10_000 });
     expect(await familiarMediaIds(page)).not.toContain(mediaPublicId);

--- a/frontend/e2e/specs/search/filter-drawer.mobile.spec.ts
+++ b/frontend/e2e/specs/search/filter-drawer.mobile.spec.ts
@@ -24,7 +24,19 @@ const QUERY = '学校';
 const drawer = (page: Page) => page.getByTestId('filter-drawer');
 const drawerToggle = (page: Page) => page.getByTestId('filter-drawer-toggle');
 
+/**
+ * Opens the drawer, or leaves it open if it already is.
+ *
+ * The guard is the whole point. Picking a title deliberately KEEPS the drawer
+ * open on its episode level -- there is a test for exactly that above -- so the
+ * callers that pick a title and then want the drawer again are already looking
+ * at it. Clicking the toggle in that state does not close-and-reopen: the open
+ * drawer's own scroll container sits over the button and swallows the click, so
+ * Playwright retried for the full minute and reported "subtree intercepts
+ * pointer events".
+ */
 async function openDrawer(page: Page) {
+  if (await drawer(page).isVisible().catch(() => false)) return;
   await drawerToggle(page).click();
   await expect(drawer(page)).toBeVisible({ timeout: 10_000 });
 }

--- a/frontend/e2e/specs/search/media-filter-account.spec.ts
+++ b/frontend/e2e/specs/search/media-filter-account.spec.ts
@@ -39,16 +39,40 @@ async function rowLabel(row: Locator): Promise<string> {
   return ((await row.locator('button span').first().textContent()) ?? '').trim();
 }
 
-/** publicId for a title, matched on whichever name the row is showing. */
+/**
+ * publicId for a title, matched on whichever name the row is showing.
+ *
+ * Pages through `/v1/media` rather than reading one response. That endpoint
+ * defaults to 20 per page and caps at 40, so a single request only ever saw the
+ * front of the catalogue -- which worked until the corpus outgrew it, and then
+ * failed as `no media in /v1/media is named "..."` for a title plainly on
+ * screen. The label comes from the filter panel, so it is by definition a title
+ * the API knows; not finding it means we stopped looking too early.
+ */
 async function publicIdForLabel(page: Page, label: string): Promise<string> {
-  const response = await page.request.get('/v1/media');
-  expect(response.ok()).toBe(true);
-  const { media } = (await response.json()) as {
-    media: Array<{ publicId: string; nameEn?: string; nameJa?: string; nameRomaji?: string }>;
-  };
-  const match = media.find((item) => [item.nameEn, item.nameJa, item.nameRomaji].some((name) => name === label));
-  expect(match, `no media in /v1/media is named "${label}"`).toBeTruthy();
-  return match!.publicId;
+  type MediaRow = { publicId: string; nameEn?: string; nameJa?: string; nameRomaji?: string };
+  const matches = (item: MediaRow) => [item.nameEn, item.nameJa, item.nameRomaji].some((name) => name === label);
+
+  let cursor: string | null = null;
+  // Bounded so a pagination bug cannot turn this into an infinite loop; 40 pages
+  // of 40 is far more catalogue than this suite will ever face.
+  for (let page_ = 0; page_ < 40; page_++) {
+    const query = new URLSearchParams({ take: '40', ...(cursor ? { cursor } : {}) });
+    const response = await page.request.get(`/v1/media?${query}`);
+    expect(response.ok(), await response.text()).toBe(true);
+    const body = (await response.json()) as {
+      media: MediaRow[];
+      pagination?: { hasMore?: boolean; cursor?: string | null };
+    };
+
+    const match = body.media.find(matches);
+    if (match) return match.publicId;
+
+    if (!body.pagination?.hasMore || !body.pagination.cursor) break;
+    cursor = body.pagination.cursor;
+  }
+
+  throw new Error(`no media in /v1/media is named "${label}"`);
 }
 
 async function familiarMediaIds(page: Page): Promise<string[]> {

--- a/frontend/e2e/specs/sentence.spec.ts
+++ b/frontend/e2e/specs/sentence.spec.ts
@@ -36,10 +36,14 @@ test.describe('Sentence page', () => {
     await expect(japaneseText).not.toBeEmpty();
   });
 
+  // English alone, because the interface language picks the translation set
+  // until a reader saves an override (`defaultTranslationLanguages`) and this
+  // suite runs signed out in `en`. The ES badge this used to assert belongs to
+  // a reader who has both, which `translation-visibility.spec.ts` covers by
+  // running in the `ja` locale.
   test('displays translations', async ({ page }) => {
     const card = await gotoSentencePage(page);
     await expect(card.getByTestId('translation-badge-EN')).toBeVisible();
-    await expect(card.getByTestId('translation-badge-ES')).toBeVisible();
   });
 
   test('displays media info', async ({ page }) => {


### PR DESCRIPTION
Third round. **210 passing, up from 114** before any of this — each fix moves the bail point (`maxFailures: 5`) and uncovers what was sitting behind it. 14 tests still have not run.

All five are specs asserting against an app that moved. **No product behaviour changes.**

| Failure | Cause |
| --- | --- |
| `activity-privacy.spec.ts:194` | `familiar-media-clear` has not existed since `ac04d42ed` |
| `filter-drawer.mobile.spec.ts:101,127` | `openDrawer` clicked a toggle that was already open |
| `media-filter-account.spec.ts:121` | `/v1/media` is paginated; the helper read one page |
| `sentence.spec.ts:39` | the ES badge again |

### `familiar-media-clear` no longer exists

`ac04d42ed` ("Account: activity, collections and settings screens") replaced one bulk **Forget which shows I study** button with a Forget on each row. The spec kept pressing the bulk one, so it sat for sixty seconds waiting on a test id nothing renders.

I checked whether this was an accidental deletion before changing the test — the composable, the parent wiring and all four i18n strings survive, which looks like a loss at first glance. It is not: `ActivityPrivacy.vue` gained `forget-familiar` taking a `mediaPublicId`, and `clearingFamiliar` was dropped from its props. Per-row replaced bulk deliberately.

The tally this test builds is a single title, so forgetting that row empties the list — exactly what the test is named for.

**Loose end, not fixed here:** `clearFamiliarTitle`, `clearFamiliarDescription`, `clearFamiliarButton` and `clearFamiliarToast` are still in all three locale files with nothing rendering them, and `useFamiliarMedia` still exposes a bulk clear nothing calls. Dead, but deleting product strings is your call, not a green-CI errand.

### `openDrawer` clicked an open drawer

Picking a title deliberately **keeps** the drawer open on its episode level — there is a passing test for precisely that. So the callers that pick a title and then want the drawer again are already looking at it, and clicking the toggle does not close-and-reopen: the open drawer's scroll container sits over the button and eats the click.

```
- <div class="overflow-y-auto overscroll-y-none flex-1 min-h-0">…</div> … subtree intercepts pointer events
- retrying click action
```

`openDrawer` is now a no-op when the drawer is already up.

### `/v1/media` is paginated

`publicIdForLabel` took the first response and searched it. That endpoint defaults to 20 per page and caps at 40, so it only ever saw the front of the catalogue — fine until the corpus outgrew it, then `no media in /v1/media is named "敷嶋てとらch."` for a title plainly on screen. It pages through with the cursor now, bounded at 40 pages. The label comes from the filter panel, so it is by definition a title the API knows; not finding it meant stopping too early.

### The ES badge, again

Eighth occurrence across five files. English alone signed out in `en`; the two-language path is covered in `ja` by `translation-visibility.spec.ts` (#511).

---

The underlying question is unchanged and still yours: **is English-only-for-English-readers the intended default?** I have now resolved eight tests in favour of it. If it is wrong, the fix is in `useTranslationVisibility` and #510, #511 and this PR all need revisiting together.