### PR TITLE
Drop the dead familiar-media bulk-clear path, and fix the last E2E failure

### DIFF
--- a/frontend/app/composables/useFamiliarMedia.ts
+++ b/frontend/app/composables/useFamiliarMedia.ts
@@ -116,21 +116,10 @@ export function useFamiliarMedia() {
     }
   };
 
-  /**
-   * The number forgotten, or `null` when the clear failed -- which a count of 0
-   * cannot say on its own, since clearing an empty tally succeeds and forgets
-   * nothing. Callers that confirm the action need the two kept apart.
-   */
-  const clear = async (): Promise<number | null> => {
-    try {
-      const data = await sdk.clearFamiliarMedia();
-      entries.value = [];
-      return data?.count ?? 0;
-    } catch (error) {
-      handleApiError('familiar-media:clear-failed', error, { toastKey: 'familiarMedia.clearError' });
-      return null;
-    }
-  };
-
-  return { entries, inferredRank, load, forget, clear };
+  // No bulk `clear` here. `ac04d42ed` replaced the one "Forget which shows I
+  // study" button with a Forget on each row, so nothing has called it since --
+  // it sat exported and unreachable, holding the last reference to a toast
+  // string. `DELETE /v1/user/familiar-media` is untouched and still the way to
+  // empty the tally in one call if a caller ever wants one again.
+  return { entries, inferredRank, load, forget };
 }

--- a/frontend/e2e/specs/search/filter-drawer.mobile.spec.ts
+++ b/frontend/e2e/specs/search/filter-drawer.mobile.spec.ts
@@ -147,8 +147,14 @@ test.describe('Media filter drawer (mobile)', () => {
 
     await openDrawer(page);
     await titleRows(page).first().click();
-    await expect(drawer(page)).toBeHidden({ timeout: 10_000 });
     await expect(page).toHaveURL(/\/media\//, { timeout: 10_000 });
+    // The drawer SURVIVES the promotion to `/media/<slug>`, and that is the
+    // point of it rather than an accident: `filterAnime` emits `preservingDrawer`
+    // on exactly this transition so the replacement instance does not replay its
+    // enter animation ("The drawer remains open across that page remount",
+    // FilterContent.vue). This used to assert `toBeHidden`, which was true
+    // before that mechanism existed and has been backwards since.
+    await expect(drawer(page)).toBeVisible();
     await search.expectResultsVisible();
     await expect(drawerToggle(page)).toBeVisible({ timeout: 10_000 });
 

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -129,7 +129,6 @@
     "capReached": "You've favorited the maximum of 100 titles. Unfavorite one to add another."
   },
   "familiarMedia": {
-    "clearError": "Couldn't clear your studied titles. Please try again.",
     "forgetError": "Couldn't forget that title. Please try again."
   },
   "mediaBrowse": {
@@ -484,7 +483,6 @@
       "trackingOffToast": "Activity tracking off",
       "familiarOnToast": "Now remembering which shows you study",
       "familiarOffToast": "No longer remembering which shows you study",
-      "clearFamiliarToast": "Study tally cleared | Study tally cleared, {count} title forgotten | Study tally cleared, {count} titles forgotten",
       "clearHistoryToast": "Activity history cleared",
       "confirmClearFamiliar": "Forget which shows you study? Your activity history is not affected.",
       "confirmClearDay": "Delete all activity for {day}? This cannot be undone.",
@@ -553,9 +551,6 @@
         "clearing": "Clearing...",
         "familiarTitle": "Remember which shows I study",
         "familiarDescription": "Keeps a monthly count per title so the titles you study sort to the top of the search media filter. Separate from your activity history.",
-        "clearFamiliarTitle": "Forget which shows I study",
-        "clearFamiliarDescription": "Deletes the tally. Your activity history is kept.",
-        "clearFamiliarButton": "Forget",
         "familiarListTitle": "Shows we think you like",
         "familiarListEmpty": "Nothing tallied yet. Export a card or play a clip and titles will show up here.",
         "familiarCounts": "{cards} · {plays} · {shares}",

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -129,7 +129,6 @@
     "capReached": "Has alcanzado el máximo de 100 títulos favoritos. Quita uno para añadir otro."
   },
   "familiarMedia": {
-    "clearError": "No se pudieron borrar tus títulos estudiados. Inténtalo de nuevo.",
     "forgetError": "No se pudo olvidar ese título. Inténtalo de nuevo."
   },
   "mediaBrowse": {
@@ -484,7 +483,6 @@
       "trackingOffToast": "Seguimiento de actividad desactivado",
       "familiarOnToast": "Ahora se recuerda qué series estudias",
       "familiarOffToast": "Ya no se recuerda qué series estudias",
-      "clearFamiliarToast": "Recuento borrado | Recuento borrado, {count} título olvidado | Recuento borrado, {count} títulos olvidados",
       "clearHistoryToast": "Historial de actividad borrado",
       "confirmClearFamiliar": "¿Olvidar qué series estudias? Tu historial de actividad no se verá afectado.",
       "confirmClearDay": "¿Eliminar toda la actividad de {day}? Esta acción no se puede deshacer.",
@@ -553,9 +551,6 @@
         "clearing": "Borrando...",
         "familiarTitle": "Recordar qué series estudio",
         "familiarDescription": "Guarda un recuento mensual por título para que los títulos que estudias aparezcan primero en el filtro de medios. Independiente de tu historial de actividad.",
-        "clearFamiliarTitle": "Olvidar qué series estudio",
-        "clearFamiliarDescription": "Borra el recuento. Tu historial de actividad se mantiene.",
-        "clearFamiliarButton": "Olvidar",
         "familiarListTitle": "Series que creemos que te gustan",
         "familiarListEmpty": "Todavía no hay recuento. Exporta una tarjeta o reproduce un clip y los títulos aparecerán aquí.",
         "familiarCounts": "{cards} · {plays} · {shares}",

--- a/frontend/i18n/locales/ja.json
+++ b/frontend/i18n/locales/ja.json
@@ -129,7 +129,6 @@
     "capReached": "お気に入りは最大100件です。追加するには一つ解除してください。"
   },
   "familiarMedia": {
-    "clearError": "学習中の作品の記録を削除できませんでした。もう一度お試しください。",
     "forgetError": "このタイトルを削除できませんでした。もう一度お試しください。"
   },
   "mediaBrowse": {
@@ -484,7 +483,6 @@
       "trackingOffToast": "アクティビティ追跡をオフにしました",
       "familiarOnToast": "学習中の作品を記憶します",
       "familiarOffToast": "学習中の作品を記憶しません",
-      "clearFamiliarToast": "カウントを削除しました（{count}作品）",
       "clearHistoryToast": "アクティビティ履歴を削除しました",
       "confirmClearFamiliar": "学習中の作品の記録を削除しますか？アクティビティ履歴には影響しません。",
       "confirmClearDay": "{day} のアクティビティをすべて削除しますか？この操作は取り消せません。",
@@ -553,9 +551,6 @@
         "clearing": "削除中...",
         "familiarTitle": "学習中の作品を記憶する",
         "familiarDescription": "作品ごとの月間カウントを保存します。学習中の作品が検索のメディアフィルター上部に表示されます。アクティビティ履歴とは別の設定です。",
-        "clearFamiliarTitle": "学習中の作品を忘れる",
-        "clearFamiliarDescription": "カウントを削除します。アクティビティ履歴は残ります。",
-        "clearFamiliarButton": "削除",
         "familiarListTitle": "気に入っていそうな作品",
         "familiarListEmpty": "まだ記録がありません。カードを書き出したりクリップを再生すると、ここに表示されます。",
         "familiarCounts": "{cards}・{plays}・{shares}",


### PR DESCRIPTION
Two commits. The second is the last hard E2E failure; the first is the cleanup you asked for.

## E2E: the drawer survives the promotion to `/media/<slug>`

`filter-drawer.mobile.spec.ts:139` was the only hard failure left after #512 — the suite ran end to end for the first time: **228 passed, 1 failed, 2 flaky**.

It asserted `toBeHidden` on the drawer after picking a title from a bare `/search`. The app says the opposite, in its own words:

```ts
// A bare search promotes a selected title into `/media/<slug>`. The drawer
// remains open across that page remount, so its replacement must not replay
// the enter animation.
if (!route.params.query && slug) emit('preservingDrawer');
```

`preservingDrawer` exists *precisely* so the drawer survives that navigation. The assertion was correct before that mechanism landed and has been backwards ever since. It now asserts the drawer stays up — the stronger guarantee, and the one the feature is actually built around.

**The two remaining flaky tests pass on retry** and do not fail the job: `activity.spec.ts:70` and `recent-searches-account.spec.ts:57`, both authenticated. Left alone — I have no evidence they are anything but timing, and I have already been wrong once today calling a real failure flaky, so I would rather name them than quietly "fix" them.

## Familiar media: delete the bulk-clear path nothing renders

`ac04d42ed` replaced the single **Forget which shows I study** button with a Forget on each row, and left the other half behind:

- `accountSettings.activity.clearFamiliarToast`
- `accountSettings.activity.privacy.clearFamiliarTitle`
- `accountSettings.activity.privacy.clearFamiliarDescription`
- `accountSettings.activity.privacy.clearFamiliarButton`
- `familiarMedia.clearError`
- `useFamiliarMedia().clear()`

Nothing in `app/` referenced any of the four `clearFamiliar*` strings. `clear()` was exported but no caller destructures it — `ActivityDashboard` takes `entries`, `load` and `forget`; `FilterContent` takes `inferredRank`; the search page takes `entries` and `load`.

The method and the fifth string go together: `clear()` held the last reference to `familiarMedia.clearError`. Leaving a dead method alive to justify a dead string is the same half-cleanup that produced this.

**Not touched:** `DELETE /v1/user/familiar-media` is still there and is still the way to empty the tally in one call — the e2e teardown uses it directly. Only the unreachable client wrapper is gone.

All three locales stay at exact key parity (0 missing, 0 extra against `en`). 672 frontend tests pass, `vue-tsc` clean, all 241 specs parse.